### PR TITLE
feat: add commands, keybindings, context menus, and custom CSS setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,48 @@
         ],
         "priority": "option"
       }
-    ]
+    ],
+    "commands": [
+      {
+        "command": "markdownLiveEditor.openEditor",
+        "title": "Open with Markdown Live Editor",
+        "category": "Markdown Live Editor"
+      }
+    ],
+    "keybindings": [
+      {
+        "key": "ctrl+shift+alt+m",
+        "command": "markdownLiveEditor.openEditor",
+        "mac": "cmd+shift+alt+m",
+        "when": "editorTextFocus && editorLangId == markdown"
+      }
+    ],
+    "menus": {
+      "explorer/context": [
+        {
+          "when": "resourceLangId == markdown",
+          "command": "markdownLiveEditor.openEditor",
+          "group": "navigation"
+        }
+      ],
+      "editor/title/context": [
+        {
+          "when": "resourceLangId == markdown",
+          "command": "markdownLiveEditor.openEditor",
+          "group": "1_open"
+        }
+      ]
+    },
+    "configuration": {
+      "title": "Markdown Live Editor",
+      "properties": {
+        "markdownLiveEditor.customCss": {
+          "type": "string",
+          "default": "",
+          "description": "Custom CSS to inject into the Markdown Live Editor."
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run package",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,8 +1,24 @@
-import type * as vscode from 'vscode';
+import * as vscode from 'vscode';
 import { MarkdownEditorProvider } from './provider/markdownEditorProvider';
 
 export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(MarkdownEditorProvider.register(context));
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand(
+			'markdownLiveEditor.openEditor',
+			(uri?: vscode.Uri) => {
+				const targetUri = uri || vscode.window.activeTextEditor?.document.uri;
+				if (targetUri) {
+					vscode.commands.executeCommand(
+						'vscode.openWith',
+						targetUri,
+						MarkdownEditorProvider.viewType,
+					);
+				}
+			},
+		),
+	);
 }
 
 export function deactivate() {}

--- a/src/provider/markdownEditorProvider.ts
+++ b/src/provider/markdownEditorProvider.ts
@@ -97,6 +97,12 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 		);
 		const nonce = getNonce();
 
+		const config = vscode.workspace.getConfiguration('markdownLiveEditor');
+		const customCss = config.get<string>('customCss', '');
+		const customStyleTag = customCss
+			? `\n\t<style nonce="${nonce}">${customCss}</style>`
+			: '';
+
 		return /* html */ `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -104,7 +110,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta http-equiv="Content-Security-Policy"
 		content="default-src 'none'; style-src ${webview.cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}' 'unsafe-eval'; img-src ${webview.cspSource} data: blob:;">
-	<link href="${styleUri}" rel="stylesheet">
+	<link href="${styleUri}" rel="stylesheet">${customStyleTag}
 	<title>Markdown Live Editor</title>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Add "Open with Markdown Live Editor" command with `Cmd+Shift+Alt+M` keybinding
- Add context menu entries for explorer and editor tab (right-click on .md files)
- Add `markdownLiveEditor.customCss` setting for user-defined styles

## Test plan
- [x] Command palette → "Open with Markdown Live Editor" が表示・実行できること
- [x] `Cmd+Shift+Alt+M` で WYSIWYG エディタに切り替えできること
- [x] エクスプローラーで .md ファイル右クリック → メニューに表示されること
- [x] エディタタブ右クリック → メニューに表示されること
- [x] 設定画面で `markdownLiveEditor.customCss` が表示・入力できること