### PR TITLE
chore: release v0.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-live-editor",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-live-editor",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
         "@milkdown/components": "^7.18.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "markdown-live-editor",
   "displayName": "Markdown Live Editor",
   "description": "WYSIWYG Markdown editor for VS Code",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "publisher": "jishii1204",
   "icon": "icon.png",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump version to 0.0.2 via `npm version patch`

## After merge
Merge 後に `v0.0.2` タグを push して auto-publish ワークフローをトリガーする:
```bash
git push origin v0.0.2
