### PR TITLE
0.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-live-editor",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-live-editor",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "MIT",
       "dependencies": {
         "@milkdown/components": "^7.18.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "markdown-live-editor",
   "displayName": "Markdown Live Editor",
   "description": "WYSIWYG Markdown editor for VS Code",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "publisher": "jishii1204",
   "icon": "icon.png",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump version to 0.0.4 for release
- Includes relative path image display (#18)

## Post-merge
1. `git checkout main && git pull`
2. `git tag v0.0.4`
3. `git push origin v0.0.4`

Tag push triggers the publish workflow (VS Code Marketplace + GitHub Release).
