### PR TITLE
0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to Markdown Live Editor will be documented in this file.
 
+## [0.0.6] - 2026-02-26
+
+### Added
+
+- Outline panel in Explorer sidebar — displays heading hierarchy (H1–H6) as a TreeView
+- Click-to-scroll: click any heading in the outline to smooth-scroll the editor to that position
+- Auto-update: outline refreshes on document edits and tab switches
+- Panel auto-hides when Markdown Live Editor is not active
+
 ## [0.0.5] - 2026-02-25
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-live-editor",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-live-editor",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "MIT",
       "dependencies": {
         "@milkdown/components": "^7.18.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "markdown-live-editor",
   "displayName": "Markdown Live Editor",
   "description": "WYSIWYG Markdown editor for VS Code",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "publisher": "jishii1204",
   "icon": "icon.png",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- バージョンを 0.0.6 に更新
- CHANGELOG に v0.0.6 エントリを追加（Outline panel 機能）

## Changes
- `package.json` / `package-lock.json` — version bump to 0.0.6
- `CHANGELOG.md` — v0.0.6 リリースノート追加
