### PR TITLE
feat: add word count and character count in status bar

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,9 +10,20 @@ export function activate(context: vscode.ExtensionContext) {
 		showCollapseAll: true,
 	});
 
+	const wordCountStatusBar = vscode.window.createStatusBarItem(
+		vscode.StatusBarAlignment.Right,
+		100,
+	);
+	wordCountStatusBar.tooltip = 'Word and character count';
+
 	context.subscriptions.push(treeView);
+	context.subscriptions.push(wordCountStatusBar);
 	context.subscriptions.push(
-		MarkdownEditorProvider.register(context, outlineProvider),
+		MarkdownEditorProvider.register(
+			context,
+			outlineProvider,
+			wordCountStatusBar,
+		),
 	);
 
 	context.subscriptions.push(


### PR DESCRIPTION
## Summary
- ステータスバーに単語数・文字数を表示（`Words: 123 | Chars: 456`）
- テキスト選択時は選択範囲のカウントも表示（`Words: 10/123 | Chars: 30/456`）
- ドキュメント編集・選択変更でリアルタイム更新
- エディタ非アクティブ時はステータスバーを自動非表示

## Changes
- `src/view/view.ts` — ワードカウントプラグイン追加（ProseMirror plugin）
- `src/provider/markdownEditorProvider.ts` — `wordCount` メッセージ受信 → StatusBarItem 更新
- `src/extension.ts` — StatusBarItem 作成・登録

## Test plan
- [x] Markdown ファイルを開き、ステータスバーにワードカウントが表示されることを確認
- [x] テキスト編集でリアルタイム更新されることを確認
- [x] テキスト選択時に選択範囲のカウントが表示されることを確認
- [x] エディタを閉じるとステータスバーからカウントが消えることを確認
- [x] タブ切り替え時に正しく更新されることを確認

Closes #24
