### PR TITLE
feat: add YAML frontmatter support with collapsible editable block

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "katex": "^0.16.33",
         "mermaid": "^11.12.3",
         "remark-emoji": "^5.0.2",
+        "remark-frontmatter": "^5.0.0",
         "remark-math": "^6.0.0"
       },
       "devDependencies": {
@@ -3823,6 +3824,18 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
@@ -3897,6 +3910,19 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fault": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-2.0.1.tgz",
+      "integrity": "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "format": "^0.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -3952,6 +3978,14 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+      "engines": {
+        "node": ">=0.4.x"
       }
     },
     "node_modules/fs-constants": {
@@ -4897,18 +4931,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/mdast-util-from-markdown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
@@ -4927,6 +4949,24 @@
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0",
         "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-frontmatter": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-2.0.1.tgz",
+      "integrity": "sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-extension-frontmatter": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -5222,6 +5262,22 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-frontmatter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-2.0.0.tgz",
+      "integrity": "sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==",
+      "license": "MIT",
+      "dependencies": {
+        "fault": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-extension-gfm": {
@@ -6795,6 +6851,22 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/remark-frontmatter": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-5.0.0.tgz",
+      "integrity": "sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-frontmatter": "^2.0.0",
+        "micromark-extension-frontmatter": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-gfm": {

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "katex": "^0.16.33",
     "mermaid": "^11.12.3",
     "remark-emoji": "^5.0.2",
+    "remark-frontmatter": "^5.0.0",
     "remark-math": "^6.0.0"
   }
 }

--- a/src/view/frontmatterPlugin.ts
+++ b/src/view/frontmatterPlugin.ts
@@ -1,0 +1,141 @@
+import type { Node } from '@milkdown/prose/model';
+import { Plugin, PluginKey } from '@milkdown/prose/state';
+import { $nodeSchema, $prose, $remark } from '@milkdown/utils';
+import remarkFrontmatter from 'remark-frontmatter';
+
+// ---------------------------------------------------------------------------
+// remark-frontmatter: parse --- YAML --- blocks
+// ---------------------------------------------------------------------------
+export const remarkFrontmatterPlugin = $remark(
+	'remarkFrontmatter',
+	() => remarkFrontmatter,
+	'yaml',
+);
+
+// ---------------------------------------------------------------------------
+// ProseMirror node schema for frontmatter
+// ---------------------------------------------------------------------------
+export const frontmatterSchema = $nodeSchema('frontmatter', () => ({
+	group: 'block',
+	atom: true,
+	defining: true,
+	selectable: true,
+	isolating: true,
+	marks: '',
+	attrs: {
+		value: { default: '' },
+	},
+	parseDOM: [
+		{
+			tag: 'div[data-type="frontmatter"]',
+			getAttrs: (dom) => {
+				if (!(dom instanceof HTMLElement)) return null;
+				return {
+					value: dom.getAttribute('data-value') || '',
+				};
+			},
+		},
+	],
+	toDOM: (node) => [
+		'div',
+		{
+			class: 'frontmatter-block',
+			'data-type': 'frontmatter',
+			'data-value': node.attrs.value,
+		},
+		`---\n${node.attrs.value}\n---`,
+	],
+	parseMarkdown: {
+		match: (node) => node.type === 'yaml',
+		runner: (state, node, type) => {
+			state.addNode(type, { value: (node.value as string) || '' });
+		},
+	},
+	toMarkdown: {
+		match: (node) => node.type.name === 'frontmatter',
+		runner: (state, node) => {
+			state.addNode('yaml', undefined, node.attrs.value as string);
+		},
+	},
+}));
+
+// ---------------------------------------------------------------------------
+// NodeView: collapsible editable frontmatter block
+// ---------------------------------------------------------------------------
+export const frontmatterViewPlugin = $prose(() => {
+	return new Plugin({
+		key: new PluginKey('frontmatter-nodeview'),
+		props: {
+			nodeViews: {
+				frontmatter: (node: Node, view, getPos) => {
+					const dom = document.createElement('div');
+					dom.className = 'frontmatter-block';
+
+					// Header (click to toggle)
+					const header = document.createElement('div');
+					header.className = 'frontmatter-header';
+
+					const toggle = document.createElement('span');
+					toggle.className = 'frontmatter-toggle';
+					toggle.textContent = '\u25B6'; // ▶
+
+					const label = document.createElement('span');
+					label.className = 'frontmatter-label';
+					label.textContent = 'Frontmatter';
+
+					header.appendChild(toggle);
+					header.appendChild(label);
+
+					// Editable textarea for YAML content
+					const textarea = document.createElement('textarea');
+					textarea.className = 'frontmatter-content';
+					let currentValue = (node.attrs.value as string) || '';
+					textarea.value = currentValue;
+					textarea.spellcheck = false;
+					textarea.rows = currentValue.split('\n').length;
+
+					dom.appendChild(header);
+					dom.appendChild(textarea);
+
+					// Collapse/expand state
+					let expanded = false;
+
+					header.addEventListener('click', () => {
+						expanded = !expanded;
+						toggle.textContent = expanded ? '\u25BC' : '\u25B6'; // ▼ or ▶
+						textarea.classList.toggle('frontmatter-content--visible', expanded);
+						if (expanded) textarea.focus();
+					});
+
+					// Sync textarea edits back to ProseMirror
+					textarea.addEventListener('input', () => {
+						const newValue = textarea.value;
+						if (newValue === currentValue) return;
+						currentValue = newValue;
+						textarea.rows = newValue.split('\n').length;
+						const pos = getPos();
+						if (pos === undefined) return;
+						view.dispatch(
+							view.state.tr.setNodeMarkup(pos, undefined, { value: newValue }),
+						);
+					});
+
+					return {
+						dom,
+						update(updatedNode: Node): boolean {
+							if (updatedNode.type.name !== 'frontmatter') return false;
+							const newValue = (updatedNode.attrs.value as string) || '';
+							if (newValue === currentValue) return true;
+							currentValue = newValue;
+							textarea.value = newValue;
+							textarea.rows = newValue.split('\n').length;
+							return true;
+						},
+						ignoreMutation: () => true,
+						stopEvent: () => true,
+					};
+				},
+			},
+		},
+	});
+});

--- a/src/view/style.css
+++ b/src/view/style.css
@@ -947,3 +947,69 @@ body {
 	overflow: hidden;
 	text-overflow: ellipsis;
 }
+
+/* ============================================
+   YAML Frontmatter
+   Collapsible editable block at document top
+   ============================================ */
+
+.frontmatter-block {
+	margin-bottom: 16px;
+	border: 1px solid var(--vscode-widget-border, #454545);
+	border-radius: 4px;
+	background-color: var(--vscode-textCodeBlock-background);
+	overflow: hidden;
+}
+
+.frontmatter-header {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 6px 12px;
+	cursor: pointer;
+	user-select: none;
+	font-size: 12px;
+	font-weight: 600;
+	color: var(--vscode-descriptionForeground, #999);
+}
+
+.frontmatter-header:hover {
+	background-color: var(--vscode-list-hoverBackground, #2a2d2e);
+}
+
+.frontmatter-toggle {
+	font-size: 10px;
+	line-height: 1;
+	flex-shrink: 0;
+	width: 12px;
+	text-align: center;
+}
+
+textarea.frontmatter-content {
+	display: none;
+	width: 100%;
+	box-sizing: border-box;
+	margin: 0;
+	padding: 12px 16px;
+	font-family: var(
+		--vscode-editor-font-family,
+		"SF Mono",
+		Monaco,
+		Menlo,
+		Consolas,
+		monospace
+	);
+	font-size: 13px;
+	line-height: 1.5;
+	color: var(--vscode-editor-foreground);
+	background-color: transparent;
+	border: none;
+	border-top: 1px solid var(--vscode-widget-border, #454545);
+	outline: none;
+	resize: none;
+	overflow: hidden;
+}
+
+textarea.frontmatter-content--visible {
+	display: block;
+}

--- a/src/view/view.ts
+++ b/src/view/view.ts
@@ -15,6 +15,11 @@ import { $prose } from '@milkdown/utils';
 import { alertPlugin } from './alertPlugin';
 import { codeBlockPlugin, highlightPlugin } from './codeBlockPlugin';
 import { emojiPlugin } from './emojiPlugin';
+import {
+	frontmatterSchema,
+	frontmatterViewPlugin,
+	remarkFrontmatterPlugin,
+} from './frontmatterPlugin';
 import { imageViewPlugin, setDocumentDirUri } from './imagePlugin';
 import {
 	mathDisplaySchema,
@@ -264,7 +269,9 @@ async function createEditor(
 		.use(gfm)
 		.use(tableBlock)
 		.config(configureTableBlock)
+		.use(remarkFrontmatterPlugin)
 		.use(remarkMathPlugin)
+		.use(frontmatterSchema)
 		.use(mathInlineSchema)
 		.use(mathDisplaySchema)
 		.use(emojiPlugin)
@@ -274,6 +281,7 @@ async function createEditor(
 		.use(codeBlockPlugin)
 		.use(highlightPlugin)
 		.use(alertPlugin)
+		.use(frontmatterViewPlugin)
 		.use(mathViewPlugin)
 		.use(imageViewPlugin)
 		.use(selectionToolbar)


### PR DESCRIPTION
## Summary
- Add YAML frontmatter (`---`) support via remark-frontmatter
- Display frontmatter as a collapsible block at the top of the editor with click-to-expand/collapse toggle
- Frontmatter is editable directly in the WYSIWYG view via textarea
- Round-trip serialization preserves frontmatter content exactly

## Test plan
- [x] Open a Markdown file with YAML frontmatter → collapsible "Frontmatter" block appears
- [x] Click header to expand/collapse → YAML content shows/hides
- [x] Edit YAML in the textarea → changes sync to the source file
- [x] Open a file without frontmatter → no frontmatter block displayed
- [x] Open and close file without editing → no false dirty state
- [x] Verify dark and light theme rendering

Closes #23