### PR TITLE
0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to Markdown Live Editor will be documented in this file.
 
+## [0.2.0] - 2026-03-02
+
+### Added
+
+- YAML Frontmatter support — `---` blocks are recognized and displayed as a collapsible block
+- Click-to-expand: click the "Frontmatter" header to reveal YAML content
+- Editable: edit frontmatter directly in the WYSIWYG view via textarea
+- Round-trip safe: frontmatter content is preserved exactly during serialization
+
 ## [0.1.0] - 2026-02-28
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-live-editor",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-live-editor",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@milkdown/components": "^7.18.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "markdown-live-editor",
   "displayName": "Markdown Live Editor",
   "description": "WYSIWYG Markdown editor for VS Code",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "publisher": "jishii1204",
   "icon": "icon.png",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump version to 0.2.0
- Add CHANGELOG entry for YAML Frontmatter support

## Test plan
- [x] `npm run compile` passes
- [x] Tag push triggers CI release
