### PR TITLE
feat: lower VS Code engine version for Cursor compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@biomejs/biome": "2.4.4",
         "@types/katex": "^0.16.8",
         "@types/node": "25.x",
-        "@types/vscode": "^1.109.0",
+        "@types/vscode": "^1.75.0",
         "@vscode/vsce": "^3.7.1",
         "esbuild": "^0.27.2",
         "npm-run-all2": "^8.0.4",
@@ -36,7 +36,7 @@
         "typescript": "^5.9.3"
       },
       "engines": {
-        "vscode": "^1.109.0"
+        "vscode": "^1.75.0"
       }
     },
     "node_modules/@antfu/install-pkg": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/jishii1204/vscode-markdown-live/issues"
   },
   "engines": {
-    "vscode": "^1.109.0"
+    "vscode": "^1.75.0"
   },
   "categories": [
     "Other"
@@ -118,7 +118,7 @@
     "@biomejs/biome": "2.4.4",
     "@types/katex": "^0.16.8",
     "@types/node": "25.x",
-    "@types/vscode": "^1.109.0",
+    "@types/vscode": "^1.75.0",
     "@vscode/vsce": "^3.7.1",
     "esbuild": "^0.27.2",
     "npm-run-all2": "^8.0.4",


### PR DESCRIPTION
## Summary
- Lower `engines.vscode` from `^1.109.0` to `^1.75.0` to support Cursor editor (engine 1.99.x)
- Lower `@types/vscode` from `^1.109.0` to `^1.75.0` accordingly
- All used VS Code APIs are available since v1.45, so no functionality is affected

## Background
Cursor is a VS Code fork with an internal engine version of 1.99.x. The previous `^1.109.0` requirement prevented the extension from activating in Cursor, despite not using any APIs introduced after v1.45.

## Test plan
- [x] Verify type check passes (`npm run check-types`)
- [x] Verify lint passes (`npm run lint`)
- [x] Verify build succeeds (`npm run compile`)
- [x] Install .vsix in VS Code and confirm normal operation
- [x] Install .vsix in Cursor and confirm normal operation
