### PR TITLE
0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-live-editor",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-live-editor",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@milkdown/components": "^7.18.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "markdown-live-editor",
   "displayName": "Markdown Live Editor",
   "description": "WYSIWYG Markdown editor for VS Code",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "publisher": "jishii1204",
   "icon": "icon.png",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump version to 0.2.1

## Changes included
- feat: lower VS Code engine version to ^1.75.0 for Cursor compatibility
- ci: add OpenVSX publish step to release workflow

## Post-merge
- Tag `v0.2.1` to trigger publish workflow (VS Code Marketplace + OpenVSX)
