### PR TITLE
docs: add v0.2.1 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Markdown Live Editor will be documented in this file.
 
+## [0.2.1] - 2026-03-02
+
+### Changed
+
+- Lower minimum VS Code engine version from `^1.109.0` to `^1.75.0` for Cursor editor compatibility
+- Add OpenVSX Registry publish step to release workflow
+
 ## [0.2.0] - 2026-03-02
 
 ### Added


### PR DESCRIPTION
## Summary
- Add CHANGELOG.md entry for v0.2.1 release

## Changes
- Cursor compatibility (engine version lowered to ^1.75.0)
- OpenVSX publish step added to CI
