### PR TITLE
refactor(protocol): unify webview-host message types and add runtime guards (#67)

### DIFF
--- a/src/protocol/messages.ts
+++ b/src/protocol/messages.ts
@@ -1,0 +1,127 @@
+export interface HeadingItem {
+	text: string;
+	level: number;
+	pos: number;
+}
+
+export interface WordCountValue {
+	words: number;
+	characters: number;
+}
+
+export interface ReadyMessage {
+	type: 'ready';
+}
+
+export interface UpdateMessage {
+	type: 'update';
+	body: string;
+}
+
+export interface InitMessage {
+	type: 'init';
+	body: string;
+	documentDirUri: string;
+}
+
+export interface ScrollToHeadingMessage {
+	type: 'scrollToHeading';
+	pos: number;
+}
+
+export interface RequestHeadingsMessage {
+	type: 'requestHeadings';
+}
+
+export interface RequestWordCountMessage {
+	type: 'requestWordCount';
+}
+
+export interface HeadingsMessage {
+	type: 'headings';
+	items: HeadingItem[];
+}
+
+export interface WordCountMessage {
+	type: 'wordCount';
+	words: number;
+	characters: number;
+	selection: WordCountValue | null;
+}
+
+export type HostToEditorMessage =
+	| InitMessage
+	| RequestHeadingsMessage
+	| RequestWordCountMessage
+	| ScrollToHeadingMessage
+	| UpdateMessage;
+
+export type EditorToHostMessage =
+	| HeadingsMessage
+	| ReadyMessage
+	| UpdateMessage
+	| WordCountMessage;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null;
+}
+
+function isHeadingItem(value: unknown): value is HeadingItem {
+	if (!isRecord(value)) return false;
+	return (
+		typeof value.text === 'string' &&
+		typeof value.level === 'number' &&
+		typeof value.pos === 'number'
+	);
+}
+
+function isWordCountValue(value: unknown): value is WordCountValue {
+	if (!isRecord(value)) return false;
+	return (
+		typeof value.words === 'number' && typeof value.characters === 'number'
+	);
+}
+
+export function isHostToEditorMessage(
+	value: unknown,
+): value is HostToEditorMessage {
+	if (!isRecord(value) || typeof value.type !== 'string') return false;
+	switch (value.type) {
+		case 'init':
+			return (
+				typeof value.body === 'string' &&
+				typeof value.documentDirUri === 'string'
+			);
+		case 'update':
+			return typeof value.body === 'string';
+		case 'scrollToHeading':
+			return typeof value.pos === 'number';
+		case 'requestHeadings':
+		case 'requestWordCount':
+			return true;
+		default:
+			return false;
+	}
+}
+
+export function isEditorToHostMessage(
+	value: unknown,
+): value is EditorToHostMessage {
+	if (!isRecord(value) || typeof value.type !== 'string') return false;
+	switch (value.type) {
+		case 'ready':
+			return true;
+		case 'update':
+			return typeof value.body === 'string';
+		case 'headings':
+			return Array.isArray(value.items) && value.items.every(isHeadingItem);
+		case 'wordCount':
+			return (
+				typeof value.words === 'number' &&
+				typeof value.characters === 'number' &&
+				(value.selection === null || isWordCountValue(value.selection))
+			);
+		default:
+			return false;
+	}
+}

--- a/src/provider/markdownEditorProvider.ts
+++ b/src/provider/markdownEditorProvider.ts
@@ -1,5 +1,10 @@
 import * as vscode from 'vscode';
-import type { HeadingItem, OutlineProvider } from './outlineProvider';
+import {
+	type HeadingItem,
+	type HostToEditorMessage,
+	isEditorToHostMessage,
+} from '../protocol/messages';
+import type { OutlineProvider } from './outlineProvider';
 
 export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 	public static readonly viewType = 'markdownLiveEditor.editor';
@@ -39,10 +44,11 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 			vscode.commands.registerCommand(
 				'markdownLiveEditor.scrollToHeading',
 				(pos: number) => {
-					provider.activeWebviewPanel?.webview.postMessage({
+					const message: HostToEditorMessage = {
 						type: 'scrollToHeading',
 						pos,
-					});
+					};
+					provider.activeWebviewPanel?.webview.postMessage(message);
 				},
 			),
 		);
@@ -86,17 +92,21 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 
 		// Handle all messages from the webview in a single listener
 		const onDidReceiveMessage = webviewPanel.webview.onDidReceiveMessage(
-			(message) => {
+			(message: unknown) => {
+				if (!isEditorToHostMessage(message)) {
+					return;
+				}
 				switch (message.type) {
 					case 'ready': {
 						const documentDirUri = webviewPanel.webview
 							.asWebviewUri(documentDir)
 							.toString();
-						webviewPanel.webview.postMessage({
+						const initMessage: HostToEditorMessage = {
 							type: 'init',
 							body: document.getText(),
 							documentDirUri,
-						});
+						};
+						webviewPanel.webview.postMessage(initMessage);
 						break;
 					}
 					case 'update': {
@@ -123,12 +133,9 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 					}
 					case 'wordCount': {
 						if (this.activeWebviewPanel === webviewPanel) {
-							const w = message.words as number;
-							const c = message.characters as number;
-							const sel = message.selection as {
-								words: number;
-								characters: number;
-							} | null;
+							const w = message.words;
+							const c = message.characters;
+							const sel = message.selection;
 							this.wordCountStatusBar.text = sel
 								? `Words: ${sel.words}/${w} | Chars: ${sel.characters}/${c}`
 								: `Words: ${w} | Chars: ${c}`;
@@ -152,10 +159,11 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 				if (currentText === lastWebviewContent) {
 					return;
 				}
-				webviewPanel.webview.postMessage({
+				const updateMessage: HostToEditorMessage = {
 					type: 'update',
 					body: currentText,
-				});
+				};
+				webviewPanel.webview.postMessage(updateMessage);
 			},
 		);
 
@@ -168,8 +176,14 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 					'markdownLiveEditor.outlineAvailable',
 					true,
 				);
-				webviewPanel.webview.postMessage({ type: 'requestHeadings' });
-				webviewPanel.webview.postMessage({ type: 'requestWordCount' });
+				const requestHeadingsMessage: HostToEditorMessage = {
+					type: 'requestHeadings',
+				};
+				const requestWordCountMessage: HostToEditorMessage = {
+					type: 'requestWordCount',
+				};
+				webviewPanel.webview.postMessage(requestHeadingsMessage);
+				webviewPanel.webview.postMessage(requestWordCountMessage);
 			} else if (this.activeWebviewPanel === webviewPanel) {
 				this.wordCountStatusBar.hide();
 			}

--- a/src/provider/outlineProvider.ts
+++ b/src/provider/outlineProvider.ts
@@ -1,11 +1,5 @@
 import * as vscode from 'vscode';
-
-/** Heading data sent from the webview */
-export interface HeadingItem {
-	text: string;
-	level: number;
-	pos: number;
-}
+import type { HeadingItem } from '../protocol/messages';
 
 class HeadingTreeItem extends vscode.TreeItem {
 	constructor(

--- a/src/view/view.ts
+++ b/src/view/view.ts
@@ -12,6 +12,11 @@ import { gfm } from '@milkdown/preset-gfm';
 import type { Node as ProseMirrorNode } from '@milkdown/prose/model';
 import { Plugin, TextSelection } from '@milkdown/prose/state';
 import { $prose } from '@milkdown/utils';
+import {
+	type EditorToHostMessage,
+	type HostToEditorMessage,
+	isHostToEditorMessage,
+} from '../protocol/messages';
 import { alertPlugin } from './alertPlugin';
 import { codeBlockPlugin, highlightPlugin } from './codeBlockPlugin';
 import {
@@ -44,7 +49,7 @@ import {
 } from './toolbarPlugin';
 
 declare function acquireVsCodeApi(): {
-	postMessage(message: unknown): void;
+	postMessage(message: EditorToHostMessage): void;
 	getState(): unknown;
 	setState(state: unknown): void;
 };
@@ -309,7 +314,11 @@ function replaceContent(newMarkdown: string): void {
 
 // Handle messages from the extension host
 window.addEventListener('message', (event) => {
-	const message = event.data;
+	const rawMessage = event.data;
+	if (!isHostToEditorMessage(rawMessage)) {
+		return;
+	}
+	const message: HostToEditorMessage = rawMessage;
 	switch (message.type) {
 		case 'init': {
 			const container = document.getElementById('editor');
@@ -341,7 +350,7 @@ window.addEventListener('message', (event) => {
 			if (!editor) break;
 			editor.action((ctx) => {
 				const view = ctx.get(editorViewCtx);
-				const pos = message.pos as number;
+				const { pos } = message;
 				const { doc } = view.state;
 				if (pos < 0 || pos >= doc.content.size) return;
 				const selection = TextSelection.near(doc.resolve(pos));

--- a/test/unit/messageProtocol.test.ts
+++ b/test/unit/messageProtocol.test.ts
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+	isEditorToHostMessage,
+	isHostToEditorMessage,
+} from '../../src/protocol/messages';
+
+describe('isHostToEditorMessage', () => {
+	it('accepts valid init and control messages', () => {
+		assert.equal(
+			isHostToEditorMessage({
+				type: 'init',
+				body: '# title',
+				documentDirUri: 'vscode-webview-resource://dir',
+			}),
+			true,
+		);
+		assert.equal(
+			isHostToEditorMessage({ type: 'scrollToHeading', pos: 10 }),
+			true,
+		);
+		assert.equal(
+			isHostToEditorMessage({ type: 'requestHeadings' }),
+			true,
+		);
+	});
+
+	it('rejects invalid host messages', () => {
+		assert.equal(isHostToEditorMessage({ type: 'init', body: 'x' }), false);
+		assert.equal(
+			isHostToEditorMessage({ type: 'scrollToHeading', pos: '10' }),
+			false,
+		);
+		assert.equal(isHostToEditorMessage({ type: 'unknown' }), false);
+	});
+});
+
+describe('isEditorToHostMessage', () => {
+	it('accepts valid editor messages', () => {
+		assert.equal(isEditorToHostMessage({ type: 'ready' }), true);
+		assert.equal(
+			isEditorToHostMessage({ type: 'update', body: '# text' }),
+			true,
+		);
+		assert.equal(
+			isEditorToHostMessage({
+				type: 'headings',
+				items: [{ text: 'H1', level: 1, pos: 0 }],
+			}),
+			true,
+		);
+		assert.equal(
+			isEditorToHostMessage({
+				type: 'wordCount',
+				words: 10,
+				characters: 42,
+				selection: { words: 2, characters: 8 },
+			}),
+			true,
+		);
+	});
+
+	it('rejects invalid editor messages', () => {
+		assert.equal(
+			isEditorToHostMessage({
+				type: 'headings',
+				items: [{ text: 'H1', level: '1', pos: 0 }],
+			}),
+			false,
+		);
+		assert.equal(
+			isEditorToHostMessage({
+				type: 'wordCount',
+				words: 10,
+				characters: 42,
+				selection: { words: '2', characters: 8 },
+			}),
+			false,
+		);
+		assert.equal(isEditorToHostMessage({ type: 'wordCount' }), false);
+	});
+});


### PR DESCRIPTION
## Summary
Implements #67 by introducing a shared message protocol between the extension host and webview, and adding runtime guards for incoming messages.

## Changes
- Added shared protocol definitions:
  - `src/protocol/messages.ts`
  - `HostToEditorMessage`
  - `EditorToHostMessage`
  - runtime guards:
    - `isHostToEditorMessage`
    - `isEditorToHostMessage`
- Updated provider-side message handling:
  - `src/provider/markdownEditorProvider.ts`
  - validates webview -> host messages before processing
  - sends host -> webview messages using shared protocol types
- Updated webview-side message handling:
  - `src/view/view.ts`
  - validates host -> webview messages before processing
  - constrains `postMessage` payloads to `EditorToHostMessage`
- Updated heading type ownership:
  - `src/provider/outlineProvider.ts`
  - imports `HeadingItem` from shared protocol module
- Added protocol unit tests:
  - `test/unit/messageProtocol.test.ts`

## Why
Previously, message payloads were implicitly typed and partially cast at use sites.  
This change makes the protocol explicit and type-safe, reducing accidental breakage and unsafe payload handling.

## Validation
Executed locally:
- `npm run check-types` ✅
- `npm run lint` ✅
- `npm run test:unit` ✅
- `npm run test:smoke` ✅

## Related Issues
- Closes #67
- Parent: #66
