### PR TITLE
chore(release): bump extension version to 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-live-editor",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-live-editor",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@milkdown/components": "^7.19.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "markdown-live-editor",
   "displayName": "Markdown Live Editor",
   "description": "WYSIWYG Markdown editor for VS Code",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "publisher": "jishii1204",
   "icon": "icon.png",
   "license": "MIT",


### PR DESCRIPTION
## Summary
This PR bumps the extension version from `0.2.1` to `0.3.0` for the recent feature additions.

## Changes
- Update `package.json` version to `0.3.0`
- Update `package-lock.json` version metadata to `0.3.0`

## Notes
- No functional code changes
- Version-only release preparation
