### PR TITLE
docs(process): add required PR quality fields and label usage guide

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,8 +4,27 @@
 ## Changes
 <!-- List the main files changed and why -->
 
+## Reproduction steps (required for bug fixes/behavior changes)
+<!-- Steps to reproduce the issue before this PR -->
+
+## Expected result
+<!-- What behavior should happen after this PR -->
+
+## Impact scope
+<!-- What areas are affected? (editor UI, sync, parsing, tests, CI, etc.) -->
+
+## Rollback condition
+<!-- Under what condition should this change be reverted? -->
+
+## Labels
+<!-- Apply labels in GitHub UI before requesting review -->
+- [ ] `quality` (for quality/reliability/process improvements)
+- [ ] One `area:*` label is applied (`area:test`, `area:sync`, `area:search`, etc.)
+
 ## Test plan
 - [ ] `npm run compile` passes locally
+- [ ] `npm run test:unit` passes locally
+- [ ] `npm run test:smoke` passes locally
 - [ ] Tested with F5 debug launch
 - [ ] Dark and light themes verified
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,23 @@ npm run lint        # Check
 npm run lint:fix    # Auto-fix
 ```
 
+## PR Labels and Quality Workflow
+
+To keep quality work discoverable and triage-friendly, apply labels on every PR:
+
+- Add `quality` for reliability/process/test/maintainability improvements
+- Add one `area:*` label that best matches the primary change area
+  - Examples: `area:test`, `area:sync`, `area:search`, `area:input`, `area:editor-core`
+
+For quality-related PRs, include these details in the PR description:
+
+- Reproduction steps (if fixing a behavior/regression)
+- Expected result
+- Impact scope
+- Rollback condition
+
+This repository tracks release-freeze readiness using issue metrics (see #66/#73), so label consistency is part of the operating rule.
+
 ## Tech Stack
 
 - TypeScript


### PR DESCRIPTION
## Summary
This PR updates contribution process docs to make quality-related PR review more consistent and traceable.

## Changes
- Update `.github/pull_request_template.md`
  - Add required sections:
    - Reproduction steps
    - Expected result
    - Impact scope
    - Rollback condition
  - Add label checklist:
    - `quality`
    - one `area:*` label
  - Add local test checks for:
    - `npm run test:unit`
    - `npm run test:smoke`
- Update `CONTRIBUTING.md`
  - Add "PR Labels and Quality Workflow" section
  - Document how to apply `quality` and `area:*` labels
  - Clarify required PR description items for quality/regression work

## Why
- Aligns PR process with quality sprint operation (#66)
- Supports metrics and freeze-exit criteria tracking (#73)
- Reduces review ambiguity and improves consistency

## Validation
- `npm run lint` passed
