### PR TITLE
feat(search): add replace UI and actions to in-editor find panel

### DIFF
--- a/src/view/style.css
+++ b/src/view/style.css
@@ -268,8 +268,9 @@ body {
 	top: 12px;
 	right: 20px;
 	z-index: 1100;
-	align-items: center;
-	gap: 6px;
+	flex-direction: column;
+	align-items: stretch;
+	gap: 4px;
 	padding: 6px;
 	background-color: var(--vscode-editorWidget-background, #252526);
 	border: 1px solid var(--vscode-widget-border, #454545);
@@ -278,6 +279,22 @@ body {
 }
 
 .search-panel[data-show="true"] {
+	display: flex;
+}
+
+.search-row {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
+
+.replace-row {
+	display: none;
+	align-items: center;
+	gap: 6px;
+}
+
+.search-panel[data-replace="true"] .replace-row {
 	display: flex;
 }
 
@@ -290,6 +307,10 @@ body {
 	background-color: var(--vscode-input-background, #3c3c3c);
 	color: var(--vscode-input-foreground, #cccccc);
 	font-size: 12px;
+}
+
+.replace-input {
+	width: 140px;
 }
 
 .search-input:focus {
@@ -314,12 +335,13 @@ body {
 
 .search-btn {
 	height: 24px;
-	min-width: 24px;
+	min-width: 28px;
 	border: none;
 	border-radius: 4px;
 	cursor: pointer;
 	background: transparent;
 	color: var(--vscode-foreground, #cccccc);
+	padding: 0 8px;
 }
 
 .search-btn:hover {

--- a/src/view/view.ts
+++ b/src/view/view.ts
@@ -246,19 +246,40 @@ function setupSearchUi(instance: Editor): void {
 		const panel = document.createElement('div');
 		panel.className = 'search-panel';
 		panel.setAttribute('data-show', 'false');
+		panel.setAttribute('data-replace', 'false');
 		panel.innerHTML = `
-			<input class="search-input" type="text" placeholder="Find" />
-			<span class="search-count">0/0</span>
-			<button class="search-btn search-prev" title="Previous">↑</button>
-			<button class="search-btn search-next" title="Next">↓</button>
-			<button class="search-btn search-close" title="Close">✕</button>
+			<div class="search-row">
+				<input class="search-input" type="text" placeholder="Find" />
+				<span class="search-count">0/0</span>
+				<button class="search-btn search-prev" title="Previous">↑</button>
+				<button class="search-btn search-next" title="Next">↓</button>
+				<button class="search-btn search-toggle-replace" title="Toggle Replace">↧</button>
+				<button class="search-btn search-close" title="Close">✕</button>
+			</div>
+			<div class="replace-row">
+				<input class="search-input replace-input" type="text" placeholder="Replace" />
+				<button class="search-btn search-replace" title="Replace">Replace</button>
+				<button class="search-btn search-replace-all" title="Replace All">All</button>
+			</div>
 		`;
 		document.body.appendChild(panel);
 
 		const input = panel.querySelector('.search-input') as HTMLInputElement;
+		const replaceInput = panel.querySelector(
+			'.replace-input',
+		) as HTMLInputElement;
 		const count = panel.querySelector('.search-count') as HTMLSpanElement;
 		const nextBtn = panel.querySelector('.search-next') as HTMLButtonElement;
 		const prevBtn = panel.querySelector('.search-prev') as HTMLButtonElement;
+		const toggleReplaceBtn = panel.querySelector(
+			'.search-toggle-replace',
+		) as HTMLButtonElement;
+		const replaceBtn = panel.querySelector(
+			'.search-replace',
+		) as HTMLButtonElement;
+		const replaceAllBtn = panel.querySelector(
+			'.search-replace-all',
+		) as HTMLButtonElement;
 		const closeBtn = panel.querySelector('.search-close') as HTMLButtonElement;
 
 		function updateCount(): void {
@@ -325,12 +346,32 @@ function setupSearchUi(instance: Editor): void {
 			input.select();
 		}
 
+		function openReplaceBar(): void {
+			openSearchBar();
+			panel.setAttribute('data-replace', 'true');
+			replaceInput.focus();
+			replaceInput.select();
+		}
+
 		function closeSearchBar(): void {
 			panel.setAttribute('data-show', 'false');
+			panel.setAttribute('data-replace', 'false');
 			input.value = '';
+			replaceInput.value = '';
 			clearSearchAction(view);
 			updateCount();
 			view.focus();
+		}
+
+		function toggleReplaceBar(): void {
+			const showReplace = panel.getAttribute('data-replace') === 'true';
+			panel.setAttribute('data-replace', showReplace ? 'false' : 'true');
+			if (showReplace) {
+				input.focus();
+				return;
+			}
+			replaceInput.focus();
+			replaceInput.select();
 		}
 
 		function onInputChange(): void {
@@ -347,6 +388,35 @@ function setupSearchUi(instance: Editor): void {
 
 		function onPrev(): void {
 			prevSearchMatchAction(view);
+			revealActiveMatch();
+			updateCount();
+		}
+
+		function onReplace(): void {
+			const state = getSearchState(view);
+			if (state.matches.length === 0) {
+				return;
+			}
+			const activeIndex = Math.max(0, state.activeIndex);
+			const match = state.matches[activeIndex];
+			view.dispatch(
+				view.state.tr.insertText(replaceInput.value, match.from, match.to),
+			);
+			revealActiveMatch();
+			updateCount();
+		}
+
+		function onReplaceAll(): void {
+			const state = getSearchState(view);
+			if (state.matches.length === 0) {
+				return;
+			}
+			let tr = view.state.tr;
+			for (let i = state.matches.length - 1; i >= 0; i--) {
+				const match = state.matches[i];
+				tr = tr.insertText(replaceInput.value, match.from, match.to);
+			}
+			view.dispatch(tr);
 			revealActiveMatch();
 			updateCount();
 		}
@@ -380,6 +450,15 @@ function setupSearchUi(instance: Editor): void {
 				}
 				return;
 			}
+			if ((event.metaKey || event.ctrlKey) && key === 'h') {
+				event.preventDefault();
+				if (panel.getAttribute('data-show') === 'true') {
+					toggleReplaceBar();
+				} else {
+					openReplaceBar();
+				}
+				return;
+			}
 			if (
 				event.key === 'Escape' &&
 				panel.getAttribute('data-show') === 'true'
@@ -407,7 +486,20 @@ function setupSearchUi(instance: Editor): void {
 		});
 		nextBtn.addEventListener('click', onNext);
 		prevBtn.addEventListener('click', onPrev);
+		toggleReplaceBtn.addEventListener('click', toggleReplaceBar);
+		replaceBtn.addEventListener('click', onReplace);
+		replaceAllBtn.addEventListener('click', onReplaceAll);
 		closeBtn.addEventListener('click', closeSearchBar);
+		replaceInput.addEventListener('keydown', (event) => {
+			if (event.key === 'Enter') {
+				event.preventDefault();
+				onReplace();
+			}
+			if (event.key === 'Escape') {
+				event.preventDefault();
+				closeSearchBar();
+			}
+		});
 		window.addEventListener('keydown', onKeyDown);
 
 		updateCount();


### PR DESCRIPTION
## Summary
This PR extends the existing in-editor Find panel with Replace functionality.

## Changes
- Add a replace row to the search panel UI (`Replace` / `All`)
- Add replace input and toggle behavior (`Ctrl/Cmd+H`)
- Implement single replace for active match
- Implement replace-all for all current matches (applied safely from end to start)
- Keep existing search navigation and count updates in sync after replacements
- Update search panel styles for two-row layout

## Files
- `src/view/view.ts`
- `src/view/style.css`

## Test / Validation
- `npm run check-types` ✅
- `npm run lint` ✅
- `npm run test:unit` ✅
- `npm run test:smoke` ✅
- Manual verification:
  - Open find with `Ctrl/Cmd+F`
  - Toggle replace with `Ctrl/Cmd+H`
  - Replace single match and replace all
  - Confirm match count/highlight behavior updates as expected

## Impact scope
- Webview editor search/replace UI and behavior (`area:search`)

## Rollback condition
- Roll back if replace introduces incorrect text substitutions, broken navigation, or unstable editor selection behavior.
