### PR TITLE
chore(release): cut v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Markdown Live Editor will be documented in this file.
 
+## [0.3.1] - 2026-03-13
+
+### Added
+
+- In-editor Replace actions in the search panel:
+  - Replace current match
+  - Replace all matches
+- `Ctrl/Cmd+H` shortcut to open/toggle Replace row
+
+### Changed
+
+- Updated README with search/replace shortcut guidance
+- Improved PR/process documentation for quality tracking
+
 ## [0.3.0] - 2026-03-09
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-live-editor",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-live-editor",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@milkdown/components": "^7.19.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "markdown-live-editor",
   "displayName": "Markdown Live Editor",
   "description": "WYSIWYG Markdown editor for VS Code",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "publisher": "jishii1204",
   "icon": "icon.png",
   "license": "MIT",


### PR DESCRIPTION
## Summary
Prepare patch release `v0.3.1`.

## Changes
- Bump version:
  - `package.json`: `0.3.0` -> `0.3.1`
  - `package-lock.json`: `0.3.0` -> `0.3.1`
- Update `CHANGELOG.md` with `0.3.1` notes

## Included in this patch
- Search panel replace actions from #88
  - Replace current match
  - Replace all matches
  - `Ctrl/Cmd+H` toggle for replace row
- Documentation/process updates from #86 and #87

## Why patch
- Adds incremental user-facing search/replace capability
- No breaking changes

## Validation
- CI checks on this PR:
  - `build` ✅
  - `security-scan` ✅
