### PR TITLE
chore: add lightweight bilingual issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,44 @@
+name: Bug report（不具合報告）
+description: Something is broken or confusing（不具合・違和感の報告）
+title: "bug: "
+labels:
+  - bug
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?（何が起きましたか？）
+      description: A short summary is enough.（短くてOKです）
+      placeholder: "Example: Cursor jumps to the end while typing in github.dev"
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: How to reproduce（再現手順）
+      description: Keep it simple. 2-5 steps is fine.（2〜5手順くらいでOK）
+      placeholder: |
+        1. Open ...
+        2. Type ...
+        3. See ...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Where did you see this?（どこで発生しましたか？）
+      options:
+        - VS Code Desktop
+        - github.dev / vscode.dev
+        - Both
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Extra notes (optional)（補足・任意）
+      description: Logs, screenshots, or anything helpful.（ログ・画像など）

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Quick question or discussion
+    url: https://github.com/ishiij-dev/vscode-markdown-live-editor/discussions
+    about: Not a bug? Feel free to start a casual discussion here.

--- a/.github/ISSUE_TEMPLATE/idea_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/idea_improvement.yml
@@ -1,0 +1,28 @@
+name: Idea / improvement（改善提案）
+description: Suggest a small improvement or new behavior（改善案・提案）
+title: "idea: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?（どんな課題がありますか？）
+      placeholder: "Example: Editing in web can feel unstable during fast typing"
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Your idea（提案内容）
+      description: Rough ideas are welcome.（ラフな案でOKです）
+      placeholder: "Example: Disable auto-sync on web while typing"
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Extra context (optional)（補足・任意）
+      description: Related issue/PR links, screenshots, etc.（関連リンクや画像など）


### PR DESCRIPTION
**PRタイトル**  
`chore: add lightweight bilingual issue templates`

**PR説明**  
`## Summary`
- `Issue` 作成フローをわかりやすくするため、軽量なテンプレートを追加。
- 英語ベースに日本語補足（かっこ書き）を付け、初見でも入力しやすい構成に。
- 堅苦しさを避けるため、必須項目は最小限に。

`## Changes`
- `.github/ISSUE_TEMPLATE/bug_report.yml` を追加
  - `What happened? / How to reproduce / Where did you see this?` を中心に最小構成
- `.github/ISSUE_TEMPLATE/idea_improvement.yml` を追加
  - `problem / proposal` の2軸で改善提案を簡潔に投稿可能
- `.github/ISSUE_TEMPLATE/config.yml` を追加
  - `blank_issues_enabled: true` を維持
  - Discussion への案内リンクを追加

`## Notes`
- 既存の Issue 運用を壊さないよう、自由投稿（blank issue）は引き続き許可。
- 目的は「報告品質の最低ラインを上げる」より「投稿しやすさを上げる」こと。