### PR TITLE
feat: improve visual line numbers for rendered Markdown rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ ext install jishii1204.markdown-live-editor
 | Setting | Description | Default |
 |---------|-------------|---------|
 | `markdownLiveEditor.customCss` | Custom CSS to inject into the editor | `""` |
-| `markdownLiveEditor.visualLineNumbers` | Show logical line numbers per rendered block in a left gutter (ignores spacing margins) | `false` |
+| `markdownLiveEditor.visualLineNumbers` | Show logical line numbers per rendered block in a left gutter (ignores spacing margins; paragraph soft wraps are not counted separately, while hard breaks are counted) | `false` |
 
 ### Export Styled HTML
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ ext install jishii1204.markdown-live-editor
 - **Emoji shortcodes** — `:smile:` → 😄, `:rocket:` → 🚀
 - **Relative image paths** — Display local images referenced with relative paths
 - **Custom CSS** — Inject your own styles via settings
+- **Visual line numbers (optional)** — Show logical line numbers per rendered block in a left gutter
 - **Theme integration** — Adapts to light, dark, and high-contrast themes
 
 ## Usage
@@ -53,6 +54,7 @@ ext install jishii1204.markdown-live-editor
 | Setting | Description | Default |
 |---------|-------------|---------|
 | `markdownLiveEditor.customCss` | Custom CSS to inject into the editor | `""` |
+| `markdownLiveEditor.visualLineNumbers` | Show logical line numbers per rendered block in a left gutter (ignores spacing margins) | `false` |
 
 ### Export Styled HTML
 

--- a/package.json
+++ b/package.json
@@ -105,6 +105,11 @@
           "type": "string",
           "default": "",
           "description": "Custom CSS to inject into the Markdown Live Editor."
+        },
+        "markdownLiveEditor.visualLineNumbers": {
+          "type": "boolean",
+          "default": false,
+          "description": "Show logical line numbers for each rendered block in a left gutter (ignores visual spacing like margins)."
         }
       }
     }

--- a/src/protocol/messages.ts
+++ b/src/protocol/messages.ts
@@ -22,6 +22,7 @@ export interface InitMessage {
 	type: 'init';
 	body: string;
 	documentDirUri: string;
+	visualLineNumbers: boolean;
 }
 
 export interface ScrollToHeadingMessage {
@@ -113,7 +114,8 @@ export function isHostToEditorMessage(
 		case 'init':
 			return (
 				typeof value.body === 'string' &&
-				typeof value.documentDirUri === 'string'
+				typeof value.documentDirUri === 'string' &&
+				typeof value.visualLineNumbers === 'boolean'
 			);
 		case 'update':
 			return typeof value.body === 'string';

--- a/src/provider/markdownEditorProvider.ts
+++ b/src/provider/markdownEditorProvider.ts
@@ -147,10 +147,17 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 						const documentDirUri = webviewPanel.webview
 							.asWebviewUri(documentDir)
 							.toString();
+						const config =
+							vscode.workspace.getConfiguration('markdownLiveEditor');
+						const visualLineNumbers = config.get<boolean>(
+							'visualLineNumbers',
+							false,
+						);
 						const initMessage: HostToEditorMessage = {
 							type: 'init',
 							body: document.getText(),
 							documentDirUri,
+							visualLineNumbers,
 						};
 						logSync('send-init', {
 							length: document.getText().length,

--- a/src/provider/markdownEditorProvider.ts
+++ b/src/provider/markdownEditorProvider.ts
@@ -23,6 +23,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 	private activeWebviewPanel: vscode.WebviewPanel | null = null;
 	private readonly styleUri: vscode.Uri;
 	private styleCache: string | null = null;
+	private syncDebugSeq = 0;
 
 	constructor(
 		private readonly context: vscode.ExtensionContext,
@@ -112,6 +113,28 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 		// Prevent one echo-back round-trip for edits originating from webview.
 		// The state is consumed on the next matching document change.
 		let syncState: WebviewSyncState = initialWebviewSyncState;
+		const isSyncDebug = vscode.workspace
+			.getConfiguration('markdownLiveEditor')
+			.get<boolean>('syncDebugLogs', false);
+
+		const hashText = (value: string): number => {
+			let hash = 2166136261;
+			for (let i = 0; i < value.length; i += 1) {
+				hash ^= value.charCodeAt(i);
+				hash = Math.imul(hash, 16777619);
+			}
+			return hash >>> 0;
+		};
+
+		const logSync = (event: string, payload: Record<string, unknown> = {}) => {
+			if (!isSyncDebug) return;
+			this.syncDebugSeq += 1;
+			console.debug(`[MLE:host:${this.syncDebugSeq}] ${event}`, {
+				ts: Date.now(),
+				version: document.version,
+				...payload,
+			});
+		};
 
 		// Handle all messages from the webview in a single listener
 		const onDidReceiveMessage = webviewPanel.webview.onDidReceiveMessage(
@@ -129,12 +152,21 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 							body: document.getText(),
 							documentDirUri,
 						};
+						logSync('send-init', {
+							length: document.getText().length,
+							hash: hashText(document.getText()),
+						});
 						webviewPanel.webview.postMessage(initMessage);
 						break;
 					}
 					case 'update': {
 						const text = message.body;
+						logSync('recv-update', {
+							length: text.length,
+							hash: hashText(text),
+						});
 						if (text === document.getText()) {
+							logSync('recv-update-skip-equal');
 							return;
 						}
 						syncState = markPendingEcho(text);
@@ -144,7 +176,12 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 							new vscode.Range(0, 0, document.lineCount, 0),
 							text,
 						);
-						vscode.workspace.applyEdit(edit);
+						logSync('apply-edit-start', {
+							targetLength: text.length,
+							targetHash: hashText(text),
+						});
+						const applied = await vscode.workspace.applyEdit(edit);
+						logSync('apply-edit-done', { applied });
 						break;
 					}
 					case 'headings': {
@@ -193,12 +230,20 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 				const { skip, next } = consumeDocumentChange(syncState, currentText);
 				syncState = next;
 				if (skip) {
+					logSync('send-update-skip-echo', {
+						length: currentText.length,
+						hash: hashText(currentText),
+					});
 					return;
 				}
 				const updateMessage: HostToEditorMessage = {
 					type: 'update',
 					body: currentText,
 				};
+				logSync('send-update', {
+					length: currentText.length,
+					hash: hashText(currentText),
+				});
 				webviewPanel.webview.postMessage(updateMessage);
 			},
 		);

--- a/src/view/editorTestUtils.ts
+++ b/src/view/editorTestUtils.ts
@@ -38,3 +38,36 @@ export function headingsEqual(a: HeadingData[], b: HeadingData[]): boolean {
 	}
 	return true;
 }
+
+export function dedupeNearbyRowTops(
+	tops: number[],
+	minDistance = 1.5,
+): number[] {
+	const sorted = [...tops].sort((a, b) => a - b);
+	const deduped: number[] = [];
+	for (const top of sorted) {
+		const last = deduped[deduped.length - 1];
+		if (last === undefined || Math.abs(top - last) > minDistance) {
+			deduped.push(top);
+		}
+	}
+	return deduped;
+}
+
+export function countParagraphRowsFromHardBreaks(
+	hardBreakCount: number,
+): number {
+	return Math.max(1, hardBreakCount + 1);
+}
+
+export function countLogicalTextLines(text: string): number {
+	return Math.max(1, text.split(/\r\n|\n|\r/).length);
+}
+
+export function shouldMergeNearbyTop(
+	currentTop: number,
+	lastTop: number,
+	threshold = 4,
+): boolean {
+	return Math.abs(currentTop - lastTop) < threshold;
+}

--- a/src/view/style.css
+++ b/src/view/style.css
@@ -59,10 +59,46 @@ body {
 .ProseMirror h4,
 .ProseMirror h5,
 .ProseMirror h6 {
+	position: relative;
 	font-weight: 600;
 	margin-top: 24px;
 	margin-bottom: 16px;
 	line-height: 1.25;
+}
+
+.visual-line-gutter {
+	display: none;
+	position: fixed;
+	width: 40px;
+	z-index: 900;
+	pointer-events: none;
+}
+
+.visual-line-gutter[data-show="true"] {
+	display: block;
+}
+
+.visual-line-number {
+	position: absolute;
+	right: 6px;
+	transform: translateY(0);
+	font-size: 11px;
+	line-height: 1;
+	color: var(--vscode-editorLineNumber-foreground, #858585);
+	opacity: 0.78;
+	font-variant-numeric: tabular-nums;
+	font-family: var(
+		--vscode-editor-font-family,
+		"SF Mono",
+		Monaco,
+		Menlo,
+		Consolas,
+		"Ubuntu Mono",
+		"Liberation Mono",
+		"DejaVu Sans Mono",
+		"Courier New",
+		monospace
+	);
 }
 
 .ProseMirror h1 {

--- a/src/view/view.ts
+++ b/src/view/view.ts
@@ -89,6 +89,7 @@ window.addEventListener('unhandledrejection', (e) => {
 let editor: Editor | null = null;
 let isUpdatingFromExtension = false;
 let pendingRemoteMarkdown: string | null = null;
+let syncDebugSeq = 0;
 
 // We compare against the normalized baseline to detect real user changes.
 // This prevents the file from being dirtied just by opening it in the editor.
@@ -100,6 +101,33 @@ let isInitializing = false;
 let updateTimer: ReturnType<typeof setTimeout> | null = null;
 const UPDATE_DELAY_MS = 300;
 let disposeSearchUi: (() => void) | null = null;
+const SYNC_DEBUG_STORAGE_KEY = 'markdownLiveEditor.syncDebug';
+
+function isSyncDebugEnabled(): boolean {
+	try {
+		return window.localStorage.getItem(SYNC_DEBUG_STORAGE_KEY) === '1';
+	} catch {
+		return false;
+	}
+}
+
+function hashText(value: string): number {
+	let hash = 2166136261;
+	for (let i = 0; i < value.length; i += 1) {
+		hash ^= value.charCodeAt(i);
+		hash = Math.imul(hash, 16777619);
+	}
+	return hash >>> 0;
+}
+
+function syncDebug(event: string, payload: Record<string, unknown> = {}): void {
+	if (!isSyncDebugEnabled()) return;
+	syncDebugSeq += 1;
+	console.debug(`[MLE:view:${syncDebugSeq}] ${event}`, {
+		ts: Date.now(),
+		...payload,
+	});
+}
 
 // ProseMirror plugin that detects doc changes and syncs to the extension host.
 // Unlike Milkdown's markdownUpdated listener, this does NOT serialize the
@@ -119,6 +147,13 @@ const syncPlugin = $prose((ctx) => {
 						const serializer = ctx.get(serializerCtx);
 						const md = cleanupTableBr(serializer(view.state.doc));
 						if (md === normalizedBaseline) return;
+						syncDebug('post-update', {
+							length: md.length,
+							hash: hashText(md),
+							focus: view.hasFocus(),
+							selectionFrom: view.state.selection.from,
+							selectionTo: view.state.selection.to,
+						});
 						vscode.postMessage({ type: 'update', body: md });
 						normalizedBaseline = md;
 					}, UPDATE_DELAY_MS);
@@ -669,12 +704,25 @@ function replaceContent(newMarkdown: string): void {
 			);
 
 			if (currentMarkdown === newMarkdown) {
+				syncDebug('replace-skip-equal', {
+					incomingLength: newMarkdown.length,
+					incomingHash: hashText(newMarkdown),
+				});
 				isUpdatingFromExtension = false;
 				return;
 			}
 
 			const parser = ctx.get(parserCtx);
 			const newDoc = parser(newMarkdown);
+			syncDebug('replace-apply', {
+				incomingLength: newMarkdown.length,
+				incomingHash: hashText(newMarkdown),
+				currentLength: currentMarkdown.length,
+				currentHash: hashText(currentMarkdown),
+				focus: view.hasFocus(),
+				selectionFrom: view.state.selection.from,
+				selectionTo: view.state.selection.to,
+			});
 			const { tr } = view.state;
 			tr.replaceWith(0, view.state.doc.content.size, newDoc.content);
 			view.dispatch(tr);
@@ -707,9 +755,16 @@ function isEditorViewFocused(): boolean {
 
 function maybeApplyPendingRemoteUpdate(): void {
 	if (!pendingRemoteMarkdown) return;
-	if (isEditorViewFocused()) return;
+	if (isEditorViewFocused()) {
+		syncDebug('pending-defer-focused', {
+			length: pendingRemoteMarkdown.length,
+			hash: hashText(pendingRemoteMarkdown),
+		});
+		return;
+	}
 	const queued = pendingRemoteMarkdown;
 	pendingRemoteMarkdown = null;
+	syncDebug('pending-apply', { length: queued.length, hash: hashText(queued) });
 	replaceContent(queued);
 }
 
@@ -829,8 +884,17 @@ window.addEventListener('message', (event) => {
 			break;
 		}
 		case 'update': {
+			syncDebug('host-update-received', {
+				length: message.body.length,
+				hash: hashText(message.body),
+				focus: isEditorViewFocused(),
+			});
 			if (isEditorViewFocused()) {
 				pendingRemoteMarkdown = message.body;
+				syncDebug('host-update-queued', {
+					length: message.body.length,
+					hash: hashText(message.body),
+				});
 				break;
 			}
 			replaceContent(message.body);

--- a/src/view/view.ts
+++ b/src/view/view.ts
@@ -88,6 +88,7 @@ window.addEventListener('unhandledrejection', (e) => {
 
 let editor: Editor | null = null;
 let isUpdatingFromExtension = false;
+let pendingRemoteMarkdown: string | null = null;
 
 // We compare against the normalized baseline to detect real user changes.
 // This prevents the file from being dirtied just by opening it in the editor.
@@ -247,6 +248,10 @@ function setupSearchUi(instance: Editor): void {
 
 	instance.action((ctx) => {
 		const view = ctx.get(editorViewCtx);
+		const onEditorFocusOut = () => {
+			setTimeout(maybeApplyPendingRemoteUpdate, 0);
+		};
+		view.dom.addEventListener('focusout', onEditorFocusOut);
 		const panel = document.createElement('div');
 		panel.className = 'search-panel';
 		panel.setAttribute('data-show', 'false');
@@ -587,6 +592,7 @@ function setupSearchUi(instance: Editor): void {
 
 		disposeSearchUi = () => {
 			window.removeEventListener('keydown', onKeyDown);
+			view.dom.removeEventListener('focusout', onEditorFocusOut);
 			setSearchStateChangeListener(null);
 			panel.remove();
 		};
@@ -683,6 +689,28 @@ function replaceContent(newMarkdown: string): void {
 	} catch {
 		isUpdatingFromExtension = false;
 	}
+}
+
+function isEditorViewFocused(): boolean {
+	if (!editor) return false;
+	let focused = false;
+	try {
+		editor.action((ctx) => {
+			const view = ctx.get(editorViewCtx);
+			focused = view.hasFocus();
+		});
+	} catch {
+		return false;
+	}
+	return focused;
+}
+
+function maybeApplyPendingRemoteUpdate(): void {
+	if (!pendingRemoteMarkdown) return;
+	if (isEditorViewFocused()) return;
+	const queued = pendingRemoteMarkdown;
+	pendingRemoteMarkdown = null;
+	replaceContent(queued);
 }
 
 function buildExportHtml(style: string, customStyle: string): string {
@@ -801,6 +829,10 @@ window.addEventListener('message', (event) => {
 			break;
 		}
 		case 'update': {
+			if (isEditorViewFocused()) {
+				pendingRemoteMarkdown = message.body;
+				break;
+			}
 			replaceContent(message.body);
 			break;
 		}
@@ -852,6 +884,10 @@ window.addEventListener('message', (event) => {
 			break;
 		}
 	}
+});
+
+window.addEventListener('blur', () => {
+	setTimeout(maybeApplyPendingRemoteUpdate, 0);
 });
 
 // Notify the extension host that the webview is ready

--- a/src/view/view.ts
+++ b/src/view/view.ts
@@ -102,6 +102,9 @@ let updateTimer: ReturnType<typeof setTimeout> | null = null;
 const UPDATE_DELAY_MS = 300;
 let disposeSearchUi: (() => void) | null = null;
 const SYNC_DEBUG_STORAGE_KEY = 'markdownLiveEditor.syncDebug';
+let visualLineNumbersEnabled = false;
+let visualLineGutter: HTMLDivElement | null = null;
+let visualLineRenderQueued = false;
 
 function isSyncDebugEnabled(): boolean {
 	try {
@@ -269,6 +272,327 @@ const wordCountPlugin = $prose((_ctx) => {
 					if (!docChanged && !selChanged) return;
 					const { from, to } = view.state.selection;
 					sendWordCount(view.state.doc, { from, to });
+				},
+			};
+		},
+	});
+});
+
+function ensureVisualLineGutter(): HTMLDivElement {
+	if (visualLineGutter) {
+		return visualLineGutter;
+	}
+	const gutter = document.createElement('div');
+	gutter.className = 'visual-line-gutter';
+	gutter.setAttribute('data-show', 'false');
+	document.body.appendChild(gutter);
+	visualLineGutter = gutter;
+	return gutter;
+}
+
+function hideVisualLineNumbers(): void {
+	document.body.setAttribute('data-visual-line-numbers', 'false');
+	if (!visualLineGutter) return;
+	visualLineGutter.setAttribute('data-show', 'false');
+}
+
+function isLogicalLineBlock(element: HTMLElement): boolean {
+	if (element.classList.contains('heading-fold-hidden')) return false;
+	if (element.tagName === 'HR') return false;
+	if (element.tagName === 'P') {
+		return element.textContent?.trim().length !== 0;
+	}
+	return true;
+}
+
+function collectListLineItems(list: HTMLElement): HTMLElement[] {
+	const rows: HTMLElement[] = [];
+	for (const child of Array.from(list.children)) {
+		if (!(child instanceof HTMLElement)) continue;
+		if (child.tagName !== 'LI') continue;
+		if (!child.classList.contains('heading-fold-hidden')) {
+			rows.push(child);
+		}
+		for (const nested of Array.from(child.children)) {
+			if (!(nested instanceof HTMLElement)) continue;
+			if (nested.tagName === 'UL' || nested.tagName === 'OL') {
+				rows.push(...collectListLineItems(nested));
+			}
+		}
+	}
+	return rows;
+}
+
+function collectTableLineItems(table: HTMLElement): HTMLElement[] {
+	const htmlTable = table as HTMLTableElement;
+	const rowsFromApi = Array.from(htmlTable.rows).filter(
+		(row): row is HTMLTableRowElement => row instanceof HTMLTableRowElement,
+	);
+	if (rowsFromApi.length > 0) {
+		return rowsFromApi.filter(
+			(row) => !row.classList.contains('heading-fold-hidden'),
+		);
+	}
+	return Array.from(table.querySelectorAll('tr')).filter(
+		(row): row is HTMLTableRowElement =>
+			row instanceof HTMLTableRowElement &&
+			!row.classList.contains('heading-fold-hidden'),
+	);
+}
+
+function findRenderableTable(container: HTMLElement): HTMLElement | null {
+	const preferred = container.querySelector('table.children');
+	if (preferred instanceof HTMLElement) {
+		return preferred;
+	}
+
+	const tables = Array.from(container.querySelectorAll('table')).filter(
+		(table): table is HTMLTableElement => table instanceof HTMLTableElement,
+	);
+	if (tables.length === 0) {
+		return null;
+	}
+
+	return tables.reduce((best, current) =>
+		current.rows.length > best.rows.length ? current : best,
+	);
+}
+
+function collectLogicalLineBlocks(container: HTMLElement): HTMLElement[] {
+	const blocks: HTMLElement[] = [];
+	for (const child of Array.from(container.children)) {
+		if (!(child instanceof HTMLElement)) continue;
+		if (child.classList.contains('heading-fold-hidden')) continue;
+
+		if (child.tagName === 'UL' || child.tagName === 'OL') {
+			blocks.push(...collectListLineItems(child));
+			continue;
+		}
+		if (child.tagName === 'TABLE') {
+			blocks.push(...collectTableLineItems(child));
+			continue;
+		}
+		const nestedTable = findRenderableTable(child);
+		if (nestedTable instanceof HTMLElement) {
+			blocks.push(...collectTableLineItems(nestedTable));
+			continue;
+		}
+		if (child.tagName === 'BLOCKQUOTE') {
+			blocks.push(...collectLogicalLineBlocks(child));
+			continue;
+		}
+		blocks.push(child);
+	}
+	return blocks.filter(isLogicalLineBlock);
+}
+
+function collectCodeBlockVisualRows(
+	block: HTMLElement,
+	proseTop: number,
+): number[] {
+	const code = block.querySelector('code');
+	if (!(code instanceof HTMLElement)) {
+		const rect = block.getBoundingClientRect();
+		return [rect.top - proseTop];
+	}
+
+	const range = document.createRange();
+	const walker = document.createTreeWalker(code, NodeFilter.SHOW_TEXT);
+	const tops: number[] = [];
+
+	let current = walker.nextNode();
+	while (current) {
+		if (current instanceof Text && current.nodeValue && current.nodeValue.length > 0) {
+			range.selectNodeContents(current);
+			const rects = Array.from(range.getClientRects());
+			for (const rect of rects) {
+				if (rect.height < 1) continue;
+				tops.push(rect.top - proseTop);
+			}
+		}
+		current = walker.nextNode();
+	}
+
+	if (tops.length === 0) {
+		const rect = block.getBoundingClientRect();
+		return [rect.top - proseTop];
+	}
+
+	tops.sort((a, b) => a - b);
+	const deduped: number[] = [];
+	for (const top of tops) {
+		const last = deduped[deduped.length - 1];
+		if (last === undefined || Math.abs(top - last) > 1.5) {
+			deduped.push(top);
+		}
+	}
+	return deduped;
+}
+
+function collectParagraphVisualRows(block: HTMLElement, proseTop: number): number[] {
+	const rect = block.getBoundingClientRect();
+	const style = window.getComputedStyle(block);
+	const lineHeightPx = Number.parseFloat(style.lineHeight);
+	const lineHeight = Number.isFinite(lineHeightPx) ? lineHeightPx : 22;
+	const hardBreakCount = block.querySelectorAll('br').length;
+	const lineCount = Math.max(1, hardBreakCount + 1);
+
+	const rows: number[] = [];
+	for (let i = 0; i < lineCount; i += 1) {
+		rows.push(rect.top - proseTop + i * lineHeight);
+	}
+	return rows;
+}
+
+function collectVisualRowsForBlock(
+	block: HTMLElement,
+	proseTop: number,
+): number[] {
+	if (block.classList.contains('frontmatter-block')) {
+		const header = block.querySelector('.frontmatter-header');
+		const textarea = block.querySelector(
+			'textarea.frontmatter-content',
+		) as HTMLTextAreaElement | null;
+		const blockRows: number[] = [];
+
+		if (header instanceof HTMLElement) {
+			const headerRect = header.getBoundingClientRect();
+			blockRows.push(headerRect.top - proseTop);
+		}
+
+		if (
+			textarea &&
+			textarea.classList.contains('frontmatter-content--visible')
+		) {
+			const textRect = textarea.getBoundingClientRect();
+			const style = window.getComputedStyle(textarea);
+			const lineHeightPx = Number.parseFloat(style.lineHeight);
+			const lineHeight = Number.isFinite(lineHeightPx) ? lineHeightPx : 20;
+			const lineCount = Math.max(
+				1,
+				textarea.value.split(/\r\n|\n|\r/).length,
+			);
+			for (let i = 0; i < lineCount; i += 1) {
+				blockRows.push(textRect.top - proseTop + i * lineHeight);
+			}
+		}
+
+		if (blockRows.length > 0) {
+			return blockRows;
+		}
+	}
+
+	if (block.tagName === 'PRE') {
+		return collectCodeBlockVisualRows(block, proseTop);
+	}
+	if (block.tagName === 'P') {
+		return collectParagraphVisualRows(block, proseTop);
+	}
+	const rect = block.getBoundingClientRect();
+	return [rect.top - proseTop];
+}
+
+function renderVisualLineNumbers(): void {
+	visualLineRenderQueued = false;
+	if (!visualLineNumbersEnabled) {
+		hideVisualLineNumbers();
+		return;
+	}
+
+	const prose = document.querySelector<HTMLElement>('.ProseMirror');
+	if (!prose) {
+		hideVisualLineNumbers();
+		return;
+	}
+
+	const proseRect = prose.getBoundingClientRect();
+	const visibleTop = Math.max(0, proseRect.top);
+	const visibleBottom = Math.min(window.innerHeight, proseRect.bottom);
+	const visibleHeight = Math.max(0, visibleBottom - visibleTop);
+	if (visibleHeight < 4) {
+		hideVisualLineNumbers();
+		return;
+	}
+
+	const blocks = collectLogicalLineBlocks(prose);
+
+	const gutter = ensureVisualLineGutter();
+	gutter.style.top = `${visibleTop}px`;
+	gutter.style.height = `${visibleHeight}px`;
+	gutter.style.left = `${Math.max(4, proseRect.left - 46)}px`;
+
+	const fragment = document.createDocumentFragment();
+	let visualLineNumber = 1;
+	let lastCountedTop = Number.NEGATIVE_INFINITY;
+	for (const block of blocks) {
+		const rect = block.getBoundingClientRect();
+		if (rect.height < 1) continue;
+		const rows = collectVisualRowsForBlock(block, proseRect.top);
+		for (const y of rows) {
+			const absoluteTop = proseRect.top + y;
+			// Merge near-identical tops that come from inline widget fragments
+			// (for example, footnote/math internals) and treat them as one visual row.
+			if (Math.abs(absoluteTop - lastCountedTop) < 4) {
+				continue;
+			}
+			lastCountedTop = absoluteTop;
+			if (
+				absoluteTop + 2 >= visibleTop - 2 &&
+				absoluteTop - 2 <= visibleBottom + 2
+			) {
+				const row = document.createElement('div');
+				row.className = 'visual-line-number visual-line-number-primary';
+				row.style.top = `${Math.round(absoluteTop - visibleTop)}px`;
+				row.textContent = `${visualLineNumber}`;
+				fragment.appendChild(row);
+			}
+			visualLineNumber += 1;
+		}
+	}
+
+	gutter.textContent = '';
+	gutter.appendChild(fragment);
+	gutter.setAttribute('data-show', 'true');
+	document.body.setAttribute('data-visual-line-numbers', 'true');
+}
+
+function scheduleVisualLineNumbersRender(): void {
+	if (visualLineRenderQueued) return;
+	visualLineRenderQueued = true;
+	requestAnimationFrame(renderVisualLineNumbers);
+}
+
+function updateVisualLineNumbers(enabled: boolean): void {
+	visualLineNumbersEnabled = enabled;
+	if (!enabled) {
+		hideVisualLineNumbers();
+		return;
+	}
+	scheduleVisualLineNumbersRender();
+}
+
+const visualLineNumbersPlugin = $prose((_ctx) => {
+	return new Plugin({
+		view() {
+			const onViewportChange = () => {
+				if (!visualLineNumbersEnabled) return;
+				scheduleVisualLineNumbersRender();
+			};
+			window.addEventListener('scroll', onViewportChange, { passive: true });
+			window.addEventListener('resize', onViewportChange);
+			return {
+				update(view, prevState) {
+					if (isInitializing || isUpdatingFromExtension) return;
+					const docChanged = !view.state.doc.eq(prevState.doc);
+					const selChanged = !view.state.selection.eq(prevState.selection);
+					if (!docChanged && !selChanged) return;
+					if (!visualLineNumbersEnabled) return;
+					scheduleVisualLineNumbersRender();
+				},
+				destroy() {
+					window.removeEventListener('scroll', onViewportChange);
+					window.removeEventListener('resize', onViewportChange);
+					hideVisualLineNumbers();
 				},
 			};
 		},
@@ -658,6 +982,7 @@ async function createEditor(
 		.use(syncPlugin)
 		.use(headingExtractPlugin)
 		.use(wordCountPlugin)
+		.use(visualLineNumbersPlugin)
 		.use(searchPlugin)
 		.use(headingFoldPlugin)
 		.use(codeBlockPlugin)
@@ -685,6 +1010,9 @@ async function createEditor(
 		);
 	});
 	setupSearchUi(instance);
+	instance.action((_ctx) => {
+		updateVisualLineNumbers(visualLineNumbersEnabled);
+	});
 
 	isInitializing = false;
 	return instance;
@@ -733,6 +1061,7 @@ function replaceContent(newMarkdown: string): void {
 			isUpdatingFromExtension = false;
 			sendHeadings(updatedDoc);
 			sendWordCount(updatedDoc);
+			updateVisualLineNumbers(visualLineNumbersEnabled);
 		});
 	} catch {
 		isUpdatingFromExtension = false;
@@ -868,6 +1197,14 @@ window.addEventListener('message', (event) => {
 			}
 			if (message.documentDirUri) {
 				setDocumentDirUri(message.documentDirUri);
+			}
+			visualLineNumbersEnabled = message.visualLineNumbers;
+			document.body.setAttribute(
+				'data-visual-line-numbers',
+				visualLineNumbersEnabled ? 'true' : 'false',
+			);
+			if (!visualLineNumbersEnabled) {
+				hideVisualLineNumbers();
 			}
 			createEditor(container, message.body)
 				.then((e) => {

--- a/src/view/view.ts
+++ b/src/view/view.ts
@@ -402,7 +402,11 @@ function collectCodeBlockVisualRows(
 
 	let current = walker.nextNode();
 	while (current) {
-		if (current instanceof Text && current.nodeValue && current.nodeValue.length > 0) {
+		if (
+			current instanceof Text &&
+			current.nodeValue &&
+			current.nodeValue.length > 0
+		) {
 			range.selectNodeContents(current);
 			const rects = Array.from(range.getClientRects());
 			for (const rect of rects) {
@@ -429,7 +433,10 @@ function collectCodeBlockVisualRows(
 	return deduped;
 }
 
-function collectParagraphVisualRows(block: HTMLElement, proseTop: number): number[] {
+function collectParagraphVisualRows(
+	block: HTMLElement,
+	proseTop: number,
+): number[] {
 	const rect = block.getBoundingClientRect();
 	const style = window.getComputedStyle(block);
 	const lineHeightPx = Number.parseFloat(style.lineHeight);
@@ -468,10 +475,7 @@ function collectVisualRowsForBlock(
 			const style = window.getComputedStyle(textarea);
 			const lineHeightPx = Number.parseFloat(style.lineHeight);
 			const lineHeight = Number.isFinite(lineHeightPx) ? lineHeightPx : 20;
-			const lineCount = Math.max(
-				1,
-				textarea.value.split(/\r\n|\n|\r/).length,
-			);
+			const lineCount = Math.max(1, textarea.value.split(/\r\n|\n|\r/).length);
 			for (let i = 0; i < lineCount; i += 1) {
 				blockRows.push(textRect.top - proseTop + i * lineHeight);
 			}

--- a/src/view/view.ts
+++ b/src/view/view.ts
@@ -25,9 +25,13 @@ import { autoPairPlugin } from './autoPairPlugin';
 import { codeBlockPlugin, highlightPlugin } from './codeBlockPlugin';
 import {
 	cleanupTableBr,
+	countLogicalTextLines,
+	countParagraphRowsFromHardBreaks,
 	countText,
+	dedupeNearbyRowTops,
 	type HeadingData,
 	headingsEqual,
+	shouldMergeNearbyTop,
 	type WordCountData,
 } from './editorTestUtils';
 import { emojiPlugin } from './emojiPlugin';
@@ -422,15 +426,7 @@ function collectCodeBlockVisualRows(
 		return [rect.top - proseTop];
 	}
 
-	tops.sort((a, b) => a - b);
-	const deduped: number[] = [];
-	for (const top of tops) {
-		const last = deduped[deduped.length - 1];
-		if (last === undefined || Math.abs(top - last) > 1.5) {
-			deduped.push(top);
-		}
-	}
-	return deduped;
+	return dedupeNearbyRowTops(tops, 1.5);
 }
 
 function collectParagraphVisualRows(
@@ -442,7 +438,7 @@ function collectParagraphVisualRows(
 	const lineHeightPx = Number.parseFloat(style.lineHeight);
 	const lineHeight = Number.isFinite(lineHeightPx) ? lineHeightPx : 22;
 	const hardBreakCount = block.querySelectorAll('br').length;
-	const lineCount = Math.max(1, hardBreakCount + 1);
+	const lineCount = countParagraphRowsFromHardBreaks(hardBreakCount);
 
 	const rows: number[] = [];
 	for (let i = 0; i < lineCount; i += 1) {
@@ -475,7 +471,7 @@ function collectVisualRowsForBlock(
 			const style = window.getComputedStyle(textarea);
 			const lineHeightPx = Number.parseFloat(style.lineHeight);
 			const lineHeight = Number.isFinite(lineHeightPx) ? lineHeightPx : 20;
-			const lineCount = Math.max(1, textarea.value.split(/\r\n|\n|\r/).length);
+			const lineCount = countLogicalTextLines(textarea.value);
 			for (let i = 0; i < lineCount; i += 1) {
 				blockRows.push(textRect.top - proseTop + i * lineHeight);
 			}
@@ -536,7 +532,7 @@ function renderVisualLineNumbers(): void {
 			const absoluteTop = proseRect.top + y;
 			// Merge near-identical tops that come from inline widget fragments
 			// (for example, footnote/math internals) and treat them as one visual row.
-			if (Math.abs(absoluteTop - lastCountedTop) < 4) {
+			if (shouldMergeNearbyTop(absoluteTop, lastCountedTop, 4)) {
 				continue;
 			}
 			lastCountedTop = absoluteTop;

--- a/test/unit/editorTestUtils.test.ts
+++ b/test/unit/editorTestUtils.test.ts
@@ -2,8 +2,12 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import {
 	cleanupTableBr,
+	countLogicalTextLines,
+	countParagraphRowsFromHardBreaks,
 	countText,
+	dedupeNearbyRowTops,
 	headingsEqual,
+	shouldMergeNearbyTop,
 	type HeadingData,
 } from '../../src/view/editorTestUtils';
 
@@ -40,5 +44,42 @@ describe('headingsEqual', () => {
 		const a: HeadingData[] = [{ text: 'A', level: 1, pos: 1 }];
 		const b: HeadingData[] = [{ text: 'A', level: 2, pos: 1 }];
 		assert.equal(headingsEqual(a, b), false);
+	});
+});
+
+describe('dedupeNearbyRowTops', () => {
+	it('merges nearby tops with threshold and keeps sorted order', () => {
+		const tops = [30, 10, 10.9, 50, 51.2, 80];
+		const actual = dedupeNearbyRowTops(tops, 1.5);
+		assert.deepEqual(actual, [10, 30, 50, 80]);
+	});
+});
+
+describe('countParagraphRowsFromHardBreaks', () => {
+	it('returns hardBreakCount + 1 with minimum 1', () => {
+		assert.equal(countParagraphRowsFromHardBreaks(0), 1);
+		assert.equal(countParagraphRowsFromHardBreaks(1), 2);
+		assert.equal(countParagraphRowsFromHardBreaks(3), 4);
+	});
+});
+
+describe('countLogicalTextLines', () => {
+	it('counts CRLF/LF/CR line endings consistently', () => {
+		assert.equal(countLogicalTextLines('a\nb\nc'), 3);
+		assert.equal(countLogicalTextLines('a\r\nb\r\nc'), 3);
+		assert.equal(countLogicalTextLines('a\rb\rc'), 3);
+		assert.equal(countLogicalTextLines('single line'), 1);
+	});
+});
+
+describe('shouldMergeNearbyTop', () => {
+	it('returns true when tops are within threshold', () => {
+		assert.equal(shouldMergeNearbyTop(101, 100, 4), true);
+		assert.equal(shouldMergeNearbyTop(103.9, 100, 4), true);
+	});
+
+	it('returns false when tops are outside threshold', () => {
+		assert.equal(shouldMergeNearbyTop(104, 100, 4), false);
+		assert.equal(shouldMergeNearbyTop(110, 100, 4), false);
 	});
 });

--- a/test/unit/messageProtocol.test.ts
+++ b/test/unit/messageProtocol.test.ts
@@ -12,6 +12,7 @@ describe('isHostToEditorMessage', () => {
 				type: 'init',
 				body: '# title',
 				documentDirUri: 'vscode-webview-resource://dir',
+				visualLineNumbers: false,
 			}),
 			true,
 		);


### PR DESCRIPTION
## Summary
This PR improves `markdownLiveEditor.visualLineNumbers` so line numbers align better with rendered content in the Live Editor.

## Changes
- Removed `sourceLineReference` and unified line reference behavior under `visualLineNumbers`
- Added row-level numbering for:
  - paragraphs with hard breaks (`<br>`)
  - list items
  - table rows
  - code blocks (visual rows)
  - frontmatter (header + expanded YAML rows)
- Fixed numbering stability during scroll (same row keeps same number)
- Reduced overlapping numbers for inline-heavy content (e.g. math / footnotes)
- Adjusted vertical alignment of gutter numbers
- Updated docs and message protocol tests

## Behavior Notes
- Visual line numbers are based on logical rendered rows.
- Soft wraps inside a paragraph are **not** counted as separate line numbers.
- Hard breaks (`<br>`) are counted as separate paragraph rows.

## Validation
- `npm run check-types` ✅
- `npm run test:unit` ✅ (21/21 pass)
- CI `build` ✅
- CI `security-scan` ✅

## Notes
- Verification fixture `test/fixtures/visual-line-numbers-check.md` is intentionally not included in this PR.
