### PR TITLE
chore: release v0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-live-editor",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-live-editor",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "license": "MIT",
       "dependencies": {
         "@milkdown/components": "^7.20.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-live-editor",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-live-editor",
-      "version": "0.5.4",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@milkdown/components": "^7.20.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "markdown-live-editor",
   "displayName": "Markdown Live Editor",
   "description": "WYSIWYG Markdown editor for VS Code",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "publisher": "jishii1204",
   "icon": "icon.png",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "markdown-live-editor",
   "displayName": "Markdown Live Editor",
   "description": "WYSIWYG Markdown editor for VS Code",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "publisher": "jishii1204",
   "icon": "icon.png",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump extension version to `0.6.0` (minor release)
- Include visual line-number feature work merged in #132

## Notes
- This release is a feature release, so version is bumped from `0.5.3` to `0.6.0`.