### PR TITLE
style: fix CSS noDescendingSpecificity warnings

### DIFF
--- a/src/view/style.css
+++ b/src/view/style.css
@@ -334,10 +334,6 @@ body {
 	display: flex;
 }
 
-.search-panel[data-export="true"] .export-row {
-	display: flex;
-}
-
 .export-row {
 	display: none;
 	align-items: center;
@@ -345,6 +341,10 @@ body {
 	padding-top: 6px;
 	border-top: 1px solid var(--vscode-widget-border, #454545);
 	margin-top: 4px;
+}
+
+.search-panel[data-export="true"] .export-row {
+	display: flex;
 }
 
 .export-label {
@@ -923,8 +923,11 @@ body {
 }
 
 .ProseMirror pre code .hljs-type,
-.ProseMirror pre code .hljs-class .hljs-title,
 .ProseMirror pre code .hljs-title {
+	color: var(--vscode-symbolIcon-classForeground, #4ec9b0);
+}
+
+.ProseMirror pre code .hljs-class .hljs-title {
 	color: var(--vscode-symbolIcon-classForeground, #4ec9b0);
 }
 


### PR DESCRIPTION
## Summary
- fix `noDescendingSpecificity` warning in search export row styles by ordering selectors from low to high specificity
- fix `noDescendingSpecificity` warning around highlight.js title selectors by splitting selector groups

## Validation
- `npm run lint`
- `npm run check-types`
- `npm run test:all`
