### PR TITLE
feat: add sync debug copy command for IME/sync troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ ext install jishii1204.markdown-live-editor
 |---------|-------------|---------|
 | `markdownLiveEditor.customCss` | Custom CSS to inject into the editor | `""` |
 | `markdownLiveEditor.visualLineNumbers` | Show logical line numbers per rendered block in a left gutter (ignores spacing margins; paragraph soft wraps are not counted separately, while hard breaks are counted) | `false` |
+| `markdownLiveEditor.syncDebugLogs` | Enable sync debug logs and allow copying recent host/webview sync events for troubleshooting | `false` |
 
 ### Export Styled HTML
 
@@ -78,6 +79,15 @@ Because the editor runs inside a webview, it uses its own Find panel.
 | Next match | `Enter`, `F3`, `Ctrl+G` (Mac: `Cmd+G`) |
 | Previous match | `Shift+Enter`, `Shift+F3`, `Shift+Ctrl+G` (Mac: `Shift+Cmd+G`) |
 | Close Find | `Esc` |
+
+### Troubleshooting Sync/IME Issues
+
+If you see cursor jumps or unexpected sync behavior:
+
+1. Enable `markdownLiveEditor.syncDebugLogs`
+2. Reproduce once in the editor
+3. Run `Markdown Live Editor: Copy Sync Debug Info`
+4. Paste the copied output into your issue report with VS Code version, OS, `files.autoSave`, and reproduction steps
 
 ## Supported Markdown Features
 

--- a/package.json
+++ b/package.json
@@ -1,159 +1,169 @@
 {
-  "name": "markdown-live-editor",
-  "displayName": "Markdown Live Editor",
-  "description": "WYSIWYG Markdown editor for VS Code",
-  "version": "0.6.0",
-  "publisher": "jishii1204",
-  "icon": "icon.png",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jishii1204/vscode-markdown-live"
-  },
-  "homepage": "https://github.com/jishii1204/vscode-markdown-live#readme",
-  "bugs": {
-    "url": "https://github.com/jishii1204/vscode-markdown-live/issues"
-  },
-  "engines": {
-    "vscode": "^1.75.0"
-  },
-  "categories": [
-    "Other"
-  ],
-  "keywords": [
-    "markdown",
-    "wysiwyg",
-    "editor",
-    "mermaid",
-    "katex"
-  ],
-  "galleryBanner": {
-    "color": "#1e1e1e",
-    "theme": "dark"
-  },
-  "activationEvents": [],
-  "main": "./dist/extension.js",
-  "browser": "./dist/web/extension.js",
-  "contributes": {
-    "customEditors": [
-      {
-        "viewType": "markdownLiveEditor.editor",
-        "displayName": "Markdown Live Editor",
-        "selector": [
-          {
-            "filenamePattern": "*.md"
-          }
-        ],
-        "priority": "option"
-      }
-    ],
-    "views": {
-      "explorer": [
-        {
-          "id": "markdownLiveEditor.outline",
-          "name": "Markdown Outline",
-          "when": "markdownLiveEditor.outlineAvailable",
-          "icon": "$(list-tree)"
-        }
-      ]
-    },
-    "commands": [
-      {
-        "command": "markdownLiveEditor.openEditor",
-        "title": "Open with Markdown Live Editor",
-        "category": "Markdown Live Editor"
-      },
-      {
-        "command": "markdownLiveEditor.exportHtml",
-        "title": "Markdown Live Editor: Export Styled HTML",
-        "category": "Markdown Live Editor"
-      },
-      {
-        "command": "markdownLiveEditor.scrollToHeading",
-        "title": "Scroll to Heading",
-        "category": "Markdown Live Editor"
-      }
-    ],
-    "keybindings": [
-      {
-        "key": "ctrl+shift+alt+m",
-        "command": "markdownLiveEditor.openEditor",
-        "mac": "cmd+shift+alt+m",
-        "when": "editorTextFocus && editorLangId == markdown"
-      }
-    ],
-    "menus": {
-      "explorer/context": [
-        {
-          "when": "resourceLangId == markdown",
-          "command": "markdownLiveEditor.openEditor",
-          "group": "navigation"
-        }
-      ],
-      "editor/title/context": [
-        {
-          "when": "resourceLangId == markdown",
-          "command": "markdownLiveEditor.openEditor",
-          "group": "1_open"
-        }
-      ]
-    },
-    "configuration": {
-      "title": "Markdown Live Editor",
-      "properties": {
-        "markdownLiveEditor.customCss": {
-          "type": "string",
-          "default": "",
-          "description": "Custom CSS to inject into the Markdown Live Editor."
-        },
-        "markdownLiveEditor.visualLineNumbers": {
-          "type": "boolean",
-          "default": false,
-          "description": "Show logical line numbers for each rendered block in a left gutter (ignores visual spacing like margins)."
-        }
-      }
-    }
-  },
-  "scripts": {
-    "vscode:prepublish": "npm run package",
-    "compile": "npm run check-types && npm run lint && node esbuild.js",
-    "watch": "npm-run-all -p watch:*",
-    "watch:esbuild": "node esbuild.js --watch",
-    "watch:tsc": "tsc --noEmit --watch --project tsconfig.json",
-    "package": "npm run check-types && npm run lint && node esbuild.js --production",
-    "check-types": "tsc --noEmit",
-    "lint": "biome check src/ esbuild.js",
-    "lint:fix": "biome check --write src/ esbuild.js",
-    "test:prepare": "tsc -p tsconfig.test.json",
-    "test:unit": "npm run test:prepare && node --test .test-dist/test/unit/*.test.js",
-    "test:smoke": "npm run test:prepare && node --test .test-dist/test/smoke/*.test.js",
-    "test:all": "npm run test:unit && npm run test:smoke"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "^2.4.11",
-    "@types/katex": "^0.16.8",
-    "@types/node": "^25.6.0",
-    "@types/vscode": "1.75.0",
-    "@vscode/vsce": "^3.7.1",
-    "esbuild": "^0.28.0",
-    "npm-run-all2": "^8.0.4",
-    "type-fest": "^5.5.0",
-    "typescript": "^6.0.2"
-  },
-  "dependencies": {
-    "@milkdown/components": "^7.20.0",
-    "@milkdown/core": "^7.20.0",
-    "@milkdown/ctx": "^7.20.0",
-    "@milkdown/plugin-slash": "^7.20.0",
-    "@milkdown/plugin-tooltip": "^7.18.0",
-    "@milkdown/preset-commonmark": "^7.18.0",
-    "@milkdown/preset-gfm": "^7.18.0",
-    "@milkdown/prose": "^7.18.0",
-    "highlight.js": "^11.11.1",
-    "katex": "^0.16.45",
-    "mermaid": "^11.14.0",
-    "remark-emoji": "^5.0.2",
-    "remark-frontmatter": "^5.0.0",
-    "remark-math": "^6.0.0"
-  }
+	"name": "markdown-live-editor",
+	"displayName": "Markdown Live Editor",
+	"description": "WYSIWYG Markdown editor for VS Code",
+	"version": "0.6.0",
+	"publisher": "jishii1204",
+	"icon": "icon.png",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/jishii1204/vscode-markdown-live"
+	},
+	"homepage": "https://github.com/jishii1204/vscode-markdown-live#readme",
+	"bugs": {
+		"url": "https://github.com/jishii1204/vscode-markdown-live/issues"
+	},
+	"engines": {
+		"vscode": "^1.75.0"
+	},
+	"categories": [
+		"Other"
+	],
+	"keywords": [
+		"markdown",
+		"wysiwyg",
+		"editor",
+		"mermaid",
+		"katex"
+	],
+	"galleryBanner": {
+		"color": "#1e1e1e",
+		"theme": "dark"
+	},
+	"activationEvents": [],
+	"main": "./dist/extension.js",
+	"browser": "./dist/web/extension.js",
+	"contributes": {
+		"customEditors": [
+			{
+				"viewType": "markdownLiveEditor.editor",
+				"displayName": "Markdown Live Editor",
+				"selector": [
+					{
+						"filenamePattern": "*.md"
+					}
+				],
+				"priority": "option"
+			}
+		],
+		"views": {
+			"explorer": [
+				{
+					"id": "markdownLiveEditor.outline",
+					"name": "Markdown Outline",
+					"when": "markdownLiveEditor.outlineAvailable",
+					"icon": "$(list-tree)"
+				}
+			]
+		},
+		"commands": [
+			{
+				"command": "markdownLiveEditor.openEditor",
+				"title": "Open with Markdown Live Editor",
+				"category": "Markdown Live Editor"
+			},
+			{
+				"command": "markdownLiveEditor.exportHtml",
+				"title": "Markdown Live Editor: Export Styled HTML",
+				"category": "Markdown Live Editor"
+			},
+			{
+				"command": "markdownLiveEditor.scrollToHeading",
+				"title": "Scroll to Heading",
+				"category": "Markdown Live Editor"
+			},
+			{
+				"command": "markdownLiveEditor.copySyncDebugInfo",
+				"title": "Markdown Live Editor: Copy Sync Debug Info",
+				"category": "Markdown Live Editor"
+			}
+		],
+		"keybindings": [
+			{
+				"key": "ctrl+shift+alt+m",
+				"command": "markdownLiveEditor.openEditor",
+				"mac": "cmd+shift+alt+m",
+				"when": "editorTextFocus && editorLangId == markdown"
+			}
+		],
+		"menus": {
+			"explorer/context": [
+				{
+					"when": "resourceLangId == markdown",
+					"command": "markdownLiveEditor.openEditor",
+					"group": "navigation"
+				}
+			],
+			"editor/title/context": [
+				{
+					"when": "resourceLangId == markdown",
+					"command": "markdownLiveEditor.openEditor",
+					"group": "1_open"
+				}
+			]
+		},
+		"configuration": {
+			"title": "Markdown Live Editor",
+			"properties": {
+				"markdownLiveEditor.customCss": {
+					"type": "string",
+					"default": "",
+					"description": "Custom CSS to inject into the Markdown Live Editor."
+				},
+				"markdownLiveEditor.visualLineNumbers": {
+					"type": "boolean",
+					"default": false,
+					"description": "Show logical line numbers for each rendered block in a left gutter (ignores visual spacing like margins)."
+				},
+				"markdownLiveEditor.syncDebugLogs": {
+					"type": "boolean",
+					"default": false,
+					"description": "Enable sync debug logs and allow copying recent host/webview sync events for troubleshooting."
+				}
+			}
+		}
+	},
+	"scripts": {
+		"vscode:prepublish": "npm run package",
+		"compile": "npm run check-types && npm run lint && node esbuild.js",
+		"watch": "npm-run-all -p watch:*",
+		"watch:esbuild": "node esbuild.js --watch",
+		"watch:tsc": "tsc --noEmit --watch --project tsconfig.json",
+		"package": "npm run check-types && npm run lint && node esbuild.js --production",
+		"check-types": "tsc --noEmit",
+		"lint": "biome check src/ esbuild.js",
+		"lint:fix": "biome check --write src/ esbuild.js",
+		"test:prepare": "tsc -p tsconfig.test.json",
+		"test:unit": "npm run test:prepare && node --test .test-dist/test/unit/*.test.js",
+		"test:smoke": "npm run test:prepare && node --test .test-dist/test/smoke/*.test.js",
+		"test:all": "npm run test:unit && npm run test:smoke"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.4.11",
+		"@types/katex": "^0.16.8",
+		"@types/node": "^25.6.0",
+		"@types/vscode": "1.75.0",
+		"@vscode/vsce": "^3.7.1",
+		"esbuild": "^0.28.0",
+		"npm-run-all2": "^8.0.4",
+		"type-fest": "^5.5.0",
+		"typescript": "^6.0.2"
+	},
+	"dependencies": {
+		"@milkdown/components": "^7.20.0",
+		"@milkdown/core": "^7.20.0",
+		"@milkdown/ctx": "^7.20.0",
+		"@milkdown/plugin-slash": "^7.20.0",
+		"@milkdown/plugin-tooltip": "^7.18.0",
+		"@milkdown/preset-commonmark": "^7.18.0",
+		"@milkdown/preset-gfm": "^7.18.0",
+		"@milkdown/prose": "^7.18.0",
+		"highlight.js": "^11.11.1",
+		"katex": "^0.16.45",
+		"mermaid": "^11.14.0",
+		"remark-emoji": "^5.0.2",
+		"remark-frontmatter": "^5.0.0",
+		"remark-math": "^6.0.0"
+	}
 }

--- a/src/protocol/messages.ts
+++ b/src/protocol/messages.ts
@@ -23,6 +23,7 @@ export interface InitMessage {
 	body: string;
 	documentDirUri: string;
 	visualLineNumbers: boolean;
+	syncDebugLogs: boolean;
 }
 
 export interface ScrollToHeadingMessage {
@@ -70,6 +71,15 @@ export interface RequestExportMessage {
 	mode: ExportMode;
 }
 
+export interface SyncDebugLogMessage {
+	type: 'syncDebugLog';
+	source: 'view';
+	event: string;
+	seq: number;
+	ts: number;
+	payload: Record<string, unknown>;
+}
+
 export type HostToEditorMessage =
 	| InitMessage
 	| RequestHeadingsMessage
@@ -84,7 +94,8 @@ export type EditorToHostMessage =
 	| UpdateMessage
 	| WordCountMessage
 	| ExportHtmlMessage
-	| RequestExportMessage;
+	| RequestExportMessage
+	| SyncDebugLogMessage;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === 'object' && value !== null;
@@ -115,7 +126,8 @@ export function isHostToEditorMessage(
 			return (
 				typeof value.body === 'string' &&
 				typeof value.documentDirUri === 'string' &&
-				typeof value.visualLineNumbers === 'boolean'
+				typeof value.visualLineNumbers === 'boolean' &&
+				typeof value.syncDebugLogs === 'boolean'
 			);
 		case 'update':
 			return typeof value.body === 'string';
@@ -163,6 +175,14 @@ export function isEditorToHostMessage(
 			return (
 				typeof value.mode === 'string' &&
 				(value.mode === 'clipboard' || value.mode === 'file')
+			);
+		case 'syncDebugLog':
+			return (
+				value.source === 'view' &&
+				typeof value.event === 'string' &&
+				typeof value.seq === 'number' &&
+				typeof value.ts === 'number' &&
+				isRecord(value.payload)
 			);
 		default:
 			return false;

--- a/src/protocol/messages.ts
+++ b/src/protocol/messages.ts
@@ -39,6 +39,11 @@ export interface RequestWordCountMessage {
 	type: 'requestWordCount';
 }
 
+export interface SetSyncDebugLogsMessage {
+	type: 'setSyncDebugLogs';
+	enabled: boolean;
+}
+
 export interface HeadingsMessage {
 	type: 'headings';
 	items: HeadingItem[];
@@ -84,6 +89,7 @@ export type HostToEditorMessage =
 	| InitMessage
 	| RequestHeadingsMessage
 	| RequestWordCountMessage
+	| SetSyncDebugLogsMessage
 	| ScrollToHeadingMessage
 	| UpdateMessage
 	| RequestExportHtmlMessage;
@@ -136,6 +142,8 @@ export function isHostToEditorMessage(
 		case 'requestHeadings':
 		case 'requestWordCount':
 			return true;
+		case 'setSyncDebugLogs':
+			return typeof value.enabled === 'boolean';
 		case 'requestExportHtml':
 			return (
 				typeof value.mode === 'string' &&

--- a/src/provider/markdownEditorProvider.ts
+++ b/src/provider/markdownEditorProvider.ts
@@ -17,14 +17,17 @@ import {
 
 export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 	public static readonly viewType = 'markdownLiveEditor.editor';
+	private static readonly maxSyncDebugEntries = 500;
 
 	private static readonly textDecoder = new TextDecoder();
 	private static readonly textEncoder = new TextEncoder();
 
 	private activeWebviewPanel: vscode.WebviewPanel | null = null;
+	private activeDocumentUri: vscode.Uri | null = null;
 	private readonly styleUri: vscode.Uri;
 	private styleCache: string | null = null;
 	private syncDebugSeq = 0;
+	private syncDebugEntries: string[] = [];
 
 	constructor(
 		private readonly context: vscode.ExtensionContext,
@@ -66,6 +69,12 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 				provider.showExportOptions(),
 			),
 		);
+		disposables.push(
+			vscode.commands.registerCommand(
+				'markdownLiveEditor.copySyncDebugInfo',
+				() => provider.copySyncDebugInfo(),
+			),
+		);
 
 		disposables.push(
 			vscode.commands.registerCommand(
@@ -105,6 +114,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 
 		// Track active panel for outline and scroll commands
 		this.activeWebviewPanel = webviewPanel;
+		this.activeDocumentUri = document.uri;
 		vscode.commands.executeCommand(
 			'setContext',
 			'markdownLiveEditor.outlineAvailable',
@@ -121,11 +131,15 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 		const logSync = (event: string, payload: Record<string, unknown> = {}) => {
 			if (!isSyncDebug) return;
 			this.syncDebugSeq += 1;
-			console.debug(`[MLE:host:${this.syncDebugSeq}] ${event}`, {
+			const entry = {
 				ts: Date.now(),
+				seq: this.syncDebugSeq,
+				event,
 				version: document.version,
 				...payload,
-			});
+			};
+			console.debug(`[MLE:host:${this.syncDebugSeq}] ${event}`, entry);
+			this.pushSyncDebugEntry('host', event, this.syncDebugSeq, entry);
 		};
 
 		// Handle all messages from the webview in a single listener
@@ -150,6 +164,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 							body: document.getText(),
 							documentDirUri,
 							visualLineNumbers,
+							syncDebugLogs: isSyncDebug,
 						};
 						logSync('send-init', {
 							length: document.getText().length,
@@ -214,6 +229,19 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 						}
 						break;
 					}
+					case 'syncDebugLog': {
+						if (!isSyncDebug) {
+							break;
+						}
+						this.pushSyncDebugEntry(
+							'view',
+							message.event,
+							message.seq,
+							message.payload,
+							message.ts,
+						);
+						break;
+					}
 				}
 			},
 		);
@@ -251,6 +279,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 		const onDidChangeViewState = webviewPanel.onDidChangeViewState((e) => {
 			if (e.webviewPanel.active) {
 				this.activeWebviewPanel = webviewPanel;
+				this.activeDocumentUri = document.uri;
 				vscode.commands.executeCommand(
 					'setContext',
 					'markdownLiveEditor.outlineAvailable',
@@ -276,6 +305,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 
 			if (this.activeWebviewPanel === webviewPanel) {
 				this.activeWebviewPanel = null;
+				this.activeDocumentUri = null;
 				this.outlineProvider.clear();
 				this.wordCountStatusBar.hide();
 				vscode.commands.executeCommand(
@@ -299,6 +329,53 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 	private getCustomStyle(): string {
 		const config = vscode.workspace.getConfiguration('markdownLiveEditor');
 		return config.get<string>('customCss', '') ?? '';
+	}
+
+	public async copySyncDebugInfo(): Promise<void> {
+		const config = vscode.workspace.getConfiguration('markdownLiveEditor');
+		const enabled = config.get<boolean>('syncDebugLogs', false);
+		if (!enabled) {
+			vscode.window.showInformationMessage(
+				'Enable markdownLiveEditor.syncDebugLogs to collect sync debug info.',
+			);
+			return;
+		}
+		if (this.syncDebugEntries.length === 0) {
+			vscode.window.showInformationMessage(
+				'No sync debug logs captured yet. Reproduce once and try again.',
+			);
+			return;
+		}
+		const now = new Date().toISOString();
+		const lines: string[] = [
+			'# Markdown Live Editor Sync Debug Info',
+			`generatedAt=${now}`,
+			`activeDocument=${this.activeDocumentUri?.toString() ?? 'unknown'}`,
+			...this.syncDebugEntries,
+		];
+		await vscode.env.clipboard.writeText(lines.join('\n'));
+		vscode.window.showInformationMessage(
+			'Copied sync debug info to clipboard.',
+		);
+	}
+
+	private pushSyncDebugEntry(
+		source: 'host' | 'view',
+		event: string,
+		seq: number,
+		payload: Record<string, unknown>,
+		ts = Date.now(),
+	): void {
+		const line = `[MLE:${source}:${seq}] ${event} ${JSON.stringify({
+			ts,
+			...payload,
+		})}`;
+		this.syncDebugEntries.push(line);
+		const overflow =
+			this.syncDebugEntries.length - MarkdownEditorProvider.maxSyncDebugEntries;
+		if (overflow > 0) {
+			this.syncDebugEntries.splice(0, overflow);
+		}
 	}
 
 	public async showExportOptions(): Promise<void> {

--- a/src/provider/markdownEditorProvider.ts
+++ b/src/provider/markdownEditorProvider.ts
@@ -124,12 +124,13 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 		// Prevent one echo-back round-trip for edits originating from webview.
 		// The state is consumed on the next matching document change.
 		let syncState: WebviewSyncState = initialWebviewSyncState;
-		const isSyncDebug = vscode.workspace
-			.getConfiguration('markdownLiveEditor')
-			.get<boolean>('syncDebugLogs', false);
+		const isSyncDebugEnabled = () =>
+			vscode.workspace
+				.getConfiguration('markdownLiveEditor')
+				.get<boolean>('syncDebugLogs', false);
 
 		const logSync = (event: string, payload: Record<string, unknown> = {}) => {
-			if (!isSyncDebug) return;
+			if (!isSyncDebugEnabled()) return;
 			this.syncDebugSeq += 1;
 			const entry = {
 				ts: Date.now(),
@@ -164,7 +165,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 							body: document.getText(),
 							documentDirUri,
 							visualLineNumbers,
-							syncDebugLogs: isSyncDebug,
+							syncDebugLogs: isSyncDebugEnabled(),
 						};
 						logSync('send-init', {
 							length: document.getText().length,
@@ -230,7 +231,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 						break;
 					}
 					case 'syncDebugLog': {
-						if (!isSyncDebug) {
+						if (!isSyncDebugEnabled()) {
 							break;
 						}
 						this.pushSyncDebugEntry(
@@ -298,10 +299,26 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 			}
 		});
 
+		const onDidChangeConfiguration = vscode.workspace.onDidChangeConfiguration(
+			(e) => {
+				if (!e.affectsConfiguration('markdownLiveEditor.syncDebugLogs')) {
+					return;
+				}
+				const enabled = isSyncDebugEnabled();
+				const message: HostToEditorMessage = {
+					type: 'setSyncDebugLogs',
+					enabled,
+				};
+				webviewPanel.webview.postMessage(message);
+				logSync('sync-debug-config-changed', { enabled });
+			},
+		);
+
 		webviewPanel.onDidDispose(() => {
 			onDidReceiveMessage.dispose();
 			onDidChangeTextDocument.dispose();
 			onDidChangeViewState.dispose();
+			onDidChangeConfiguration.dispose();
 
 			if (this.activeWebviewPanel === webviewPanel) {
 				this.activeWebviewPanel = null;

--- a/src/view/view.ts
+++ b/src/view/view.ts
@@ -98,6 +98,15 @@ const SYNC_DEBUG_STORAGE_KEY = 'markdownLiveEditor.syncDebug';
 let visualLineNumbersEnabled = false;
 let syncDebugLogsEnabled = false;
 
+function setSyncDebugLogsEnabled(enabled: boolean): void {
+	syncDebugLogsEnabled = enabled;
+	try {
+		window.localStorage.setItem(SYNC_DEBUG_STORAGE_KEY, enabled ? '1' : '0');
+	} catch {
+		// Ignore localStorage failures in constrained webview environments.
+	}
+}
+
 function isSyncDebugEnabled(): boolean {
 	if (syncDebugLogsEnabled) return true;
 	try {
@@ -524,15 +533,7 @@ window.addEventListener('message', (event) => {
 			if (message.documentDirUri) {
 				setDocumentDirUri(message.documentDirUri);
 			}
-			syncDebugLogsEnabled = message.syncDebugLogs;
-			try {
-				window.localStorage.setItem(
-					SYNC_DEBUG_STORAGE_KEY,
-					syncDebugLogsEnabled ? '1' : '0',
-				);
-			} catch {
-				// Ignore localStorage failures in constrained webview environments.
-			}
+			setSyncDebugLogsEnabled(message.syncDebugLogs);
 			visualLineNumbersEnabled = message.visualLineNumbers;
 			visualLineNumbersController.updateEnabled(visualLineNumbersEnabled);
 			createEditor(container, message.body)
@@ -611,6 +612,10 @@ window.addEventListener('message', (event) => {
 				html,
 				mode: request.mode,
 			});
+			break;
+		}
+		case 'setSyncDebugLogs': {
+			setSyncDebugLogsEnabled(message.enabled);
 			break;
 		}
 	}

--- a/src/view/view.ts
+++ b/src/view/view.ts
@@ -96,8 +96,10 @@ const UPDATE_DELAY_MS = 300;
 let disposeSearchUi: (() => void) | null = null;
 const SYNC_DEBUG_STORAGE_KEY = 'markdownLiveEditor.syncDebug';
 let visualLineNumbersEnabled = false;
+let syncDebugLogsEnabled = false;
 
 function isSyncDebugEnabled(): boolean {
+	if (syncDebugLogsEnabled) return true;
 	try {
 		return window.localStorage.getItem(SYNC_DEBUG_STORAGE_KEY) === '1';
 	} catch {
@@ -108,9 +110,18 @@ function isSyncDebugEnabled(): boolean {
 function syncDebug(event: string, payload: Record<string, unknown> = {}): void {
 	if (!isSyncDebugEnabled()) return;
 	syncDebugSeq += 1;
+	const ts = Date.now();
 	console.debug(`[MLE:view:${syncDebugSeq}] ${event}`, {
-		ts: Date.now(),
+		ts,
 		...payload,
+	});
+	vscode.postMessage({
+		type: 'syncDebugLog',
+		source: 'view',
+		event,
+		seq: syncDebugSeq,
+		ts,
+		payload,
 	});
 }
 
@@ -512,6 +523,15 @@ window.addEventListener('message', (event) => {
 			}
 			if (message.documentDirUri) {
 				setDocumentDirUri(message.documentDirUri);
+			}
+			syncDebugLogsEnabled = message.syncDebugLogs;
+			try {
+				window.localStorage.setItem(
+					SYNC_DEBUG_STORAGE_KEY,
+					syncDebugLogsEnabled ? '1' : '0',
+				);
+			} catch {
+				// Ignore localStorage failures in constrained webview environments.
 			}
 			visualLineNumbersEnabled = message.visualLineNumbers;
 			visualLineNumbersController.updateEnabled(visualLineNumbersEnabled);

--- a/test/unit/messageProtocol.test.ts
+++ b/test/unit/messageProtocol.test.ts
@@ -22,12 +22,20 @@ describe('isHostToEditorMessage', () => {
 			true,
 		);
 		assert.equal(isHostToEditorMessage({ type: 'requestHeadings' }), true);
+		assert.equal(
+			isHostToEditorMessage({ type: 'setSyncDebugLogs', enabled: true }),
+			true,
+		);
 	});
 
 	it('rejects invalid host messages', () => {
 		assert.equal(isHostToEditorMessage({ type: 'init', body: 'x' }), false);
 		assert.equal(
 			isHostToEditorMessage({ type: 'scrollToHeading', pos: '10' }),
+			false,
+		);
+		assert.equal(
+			isHostToEditorMessage({ type: 'setSyncDebugLogs', enabled: 'true' }),
 			false,
 		);
 		assert.equal(isHostToEditorMessage({ type: 'unknown' }), false);

--- a/test/unit/messageProtocol.test.ts
+++ b/test/unit/messageProtocol.test.ts
@@ -13,6 +13,7 @@ describe('isHostToEditorMessage', () => {
 				body: '# title',
 				documentDirUri: 'vscode-webview-resource://dir',
 				visualLineNumbers: false,
+				syncDebugLogs: false,
 			}),
 			true,
 		);
@@ -20,10 +21,7 @@ describe('isHostToEditorMessage', () => {
 			isHostToEditorMessage({ type: 'scrollToHeading', pos: 10 }),
 			true,
 		);
-		assert.equal(
-			isHostToEditorMessage({ type: 'requestHeadings' }),
-			true,
-		);
+		assert.equal(isHostToEditorMessage({ type: 'requestHeadings' }), true);
 	});
 
 	it('rejects invalid host messages', () => {
@@ -59,6 +57,17 @@ describe('isEditorToHostMessage', () => {
 			}),
 			true,
 		);
+		assert.equal(
+			isEditorToHostMessage({
+				type: 'syncDebugLog',
+				source: 'view',
+				event: 'host-update-queued',
+				seq: 3,
+				ts: 1_234_567_890,
+				payload: { length: 42 },
+			}),
+			true,
+		);
 	});
 
 	it('rejects invalid editor messages', () => {
@@ -75,6 +84,17 @@ describe('isEditorToHostMessage', () => {
 				words: 10,
 				characters: 42,
 				selection: { words: '2', characters: 8 },
+			}),
+			false,
+		);
+		assert.equal(
+			isEditorToHostMessage({
+				type: 'syncDebugLog',
+				source: 'host',
+				event: 'x',
+				seq: 1,
+				ts: 1,
+				payload: {},
 			}),
 			false,
 		);


### PR DESCRIPTION
## Summary
- add `markdownLiveEditor.syncDebugLogs` setting to explicitly enable sync debug collection
- add command: `Markdown Live Editor: Copy Sync Debug Info`
- collect host-side sync logs and merge webview sync logs via a new protocol message
- include `syncDebugLogs` in init message so webview logging matches extension setting
- document IME/sync troubleshooting flow in README
- update protocol message tests for new fields/messages

## How to use
1. Enable `markdownLiveEditor.syncDebugLogs`
2. Reproduce sync/cursor issue once
3. Run `Markdown Live Editor: Copy Sync Debug Info`
4. Paste output into issue report

## Validation
- `npm run lint`
- `npm run check-types`
- `npm run test:all`