### PR TITLE
chore: release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to Markdown Live Editor will be documented in this file.
 
+## [0.6.1] - 2026-04-13
+
+### Added
+
+- Added `markdownLiveEditor.syncDebugLogs` setting and `Markdown Live Editor: Copy Sync Debug Info` command for sync/IME troubleshooting
+- Added host/view sync debug aggregation so copied diagnostics include both extension-host and webview events
+- Added unit test coverage for shared hash utility, visual-line update decision helper, and search hotkey wiring
+
+### Changed
+
+- Refactored webview editor code by splitting large `view.ts` responsibilities into focused modules (`searchPanel`, `visualLineNumbers`, shared helpers)
+- Made sync debug logging toggle apply immediately to already-open editor panels without requiring reopen
+
+### Fixed
+
+- Fixed CSS `noDescendingSpecificity` lint warnings in search export row and highlight selector blocks
+
 ## [0.6.0] - 2026-04-12
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-live-editor",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-live-editor",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@milkdown/components": "^7.20.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "markdown-live-editor",
 	"displayName": "Markdown Live Editor",
 	"description": "WYSIWYG Markdown editor for VS Code",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"publisher": "jishii1204",
 	"icon": "icon.png",
 	"license": "MIT",


### PR DESCRIPTION
## Summary
- bump extension version to `0.6.1`
- update `CHANGELOG.md` with `0.6.1` release notes (sync debug command, refactor/test additions, CSS lint warning fix)

## Validation
- `npm run lint`
- `npm run check-types`
- `npm run test:all`