### PR TITLE
chore: add GitHub Sponsors support links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [ishiij-dev]

--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ If you see cursor jumps or unexpected sync behavior:
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and build instructions.
 
+## Support
+
+If Markdown Live Editor helps your workflow, you can support ongoing maintenance and improvements:
+
+- GitHub Sponsors: https://github.com/sponsors/ishiij-dev
+
+Support is optional and does not affect feature availability.
+
 ## License
 
 [MIT](LICENSE)


### PR DESCRIPTION
## Summary
- add .github/FUNDING.yml with GitHub Sponsors account (ishiij-dev)
- add a Support section in README with the GitHub Sponsors link
- clarify support is optional and does not gate features

## Notes
- Buy Me a Coffee link is intentionally omitted for now
