### PR TITLE
chore: release v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Markdown Live Editor will be documented in this file.
 
+## [0.6.2] - 2026-04-20
+
+### Added
+
+- Added GitHub Sponsors funding configuration via `.github/FUNDING.yml`
+- Added a `Support` section in README with a GitHub Sponsors link
+
+### Changed
+
+- Updated `dompurify` from `3.3.2` to `3.4.0` (dependabot)
+
 ## [0.6.1] - 2026-04-13
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "markdown-live-editor",
-	"version": "0.6.1",
+	"version": "0.6.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "markdown-live-editor",
-			"version": "0.6.1",
+			"version": "0.6.2",
 			"license": "MIT",
 			"dependencies": {
 				"@milkdown/components": "^7.20.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "markdown-live-editor",
 	"displayName": "Markdown Live Editor",
 	"description": "WYSIWYG Markdown editor for VS Code",
-	"version": "0.6.1",
+	"version": "0.6.2",
 	"publisher": "jishii1204",
 	"icon": "icon.png",
 	"license": "MIT",


### PR DESCRIPTION
## Summary
- bump extension version to `0.6.2`
- update `CHANGELOG.md` for `0.6.2` (GitHub Sponsors support link and dompurify dependency update)
- refresh `package-lock.json` metadata for the new version

## Validation
- npm run lint
- npm run check-types
- npm run test:all
