### PR TITLE
chore(deps): update uuid to 14.0.0 to resolve GHSA-w5hq-g745-h8pq

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7899,16 +7899,16 @@
 			"optional": true
 		},
 		"node_modules/uuid": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-			"integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
 			"funding": [
 				"https://github.com/sponsors/broofa",
 				"https://github.com/sponsors/ctavan"
 			],
 			"license": "MIT",
 			"bin": {
-				"uuid": "dist/esm/bin/uuid"
+				"uuid": "dist-node/bin/uuid"
 			}
 		},
 		"node_modules/validate-npm-package-license": {


### PR DESCRIPTION
## Summary

This PR addresses the Dependabot security alert for `uuid` (`GHSA-w5hq-g745-h8pq`) by updating the lockfile-resolved dependency version.

## Changes

- Updated lockfile-resolved `uuid` version to `14.0.0`
- No application source code changes (dependency update only)

## Validation

- Ran `npm audit` and confirmed the targeted runtime-side `uuid` vulnerability is resolved
- Ran unit tests: all passed

## Impact

- Dependency-only update with no intended functional behavior changes
- Improves security posture by removing the reported vulnerable runtime path