### PR TITLE
chore(deps): apply audit fix for transitive dev vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -164,9 +164,9 @@
 			}
 		},
 		"node_modules/@azure/identity": {
-			"version": "4.13.0",
-			"resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.0.tgz",
-			"integrity": "sha512-uWC0fssc+hs1TGGVkkghiaFkkS7NkTxfnCH+Hdg+yTehTpMcehpok4PgUKKdyCH+9ldu6FhiHRv84Ntqj1vVcw==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.1.tgz",
+			"integrity": "sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -177,8 +177,8 @@
 				"@azure/core-tracing": "^1.0.0",
 				"@azure/core-util": "^1.11.0",
 				"@azure/logger": "^1.0.0",
-				"@azure/msal-browser": "^4.2.0",
-				"@azure/msal-node": "^3.5.0",
+				"@azure/msal-browser": "^5.5.0",
+				"@azure/msal-node": "^5.1.0",
 				"open": "^10.1.0",
 				"tslib": "^2.2.0"
 			},
@@ -201,22 +201,22 @@
 			}
 		},
 		"node_modules/@azure/msal-browser": {
-			"version": "4.29.0",
-			"resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.29.0.tgz",
-			"integrity": "sha512-/f3eHkSNUTl6DLQHm+bKecjBKcRQxbd/XLx8lvSYp8Nl/HRyPuIPOijt9Dt0sH50/SxOwQ62RnFCmFlGK+bR/w==",
+			"version": "5.11.0",
+			"resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.11.0.tgz",
+			"integrity": "sha512-zkGNYS3TwY8lUpPIafAmsFCYZbgFixY9y/LZB9GUg0IILoHTqpN26j5OrkL1AQThh/YdZsawe4iWXfp85lFVxg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@azure/msal-common": "15.15.0"
+				"@azure/msal-common": "16.6.2"
 			},
 			"engines": {
 				"node": ">=0.8.0"
 			}
 		},
 		"node_modules/@azure/msal-common": {
-			"version": "15.15.0",
-			"resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.15.0.tgz",
-			"integrity": "sha512-/n+bN0AKlVa+AOcETkJSKj38+bvFs78BaP4rNtv3MJCmPH0YrHiskMRe74OhyZ5DZjGISlFyxqvf9/4QVEi2tw==",
+			"version": "16.6.2",
+			"resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.6.2.tgz",
+			"integrity": "sha512-hQjjsekAjB00cM1EmatWJlzhEoK2Qhz7Rj5gvM6tYf8iL7RM3tkxlpU9fG0+ofkulzg9AEEA6dIEnSmDr5ZqUA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -224,28 +224,17 @@
 			}
 		},
 		"node_modules/@azure/msal-node": {
-			"version": "3.8.8",
-			"resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.8.8.tgz",
-			"integrity": "sha512-+f1VrJH1iI517t4zgmuhqORja0bL6LDQXfBqkjuMmfTYXTQQnh1EvwwxO3UbKLT05N0obF72SRHFrC1RBDv5Gg==",
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.2.2.tgz",
+			"integrity": "sha512-toS+2AePxqyzb0YOKttDOOiSl3jrkK9aiqIvpurpis0O34QcIS5gToqrgT39p04Dpxw3YoUU0lxJKTpSFFfA6Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@azure/msal-common": "15.15.0",
-				"jsonwebtoken": "^9.0.0",
-				"uuid": "^8.3.0"
+				"@azure/msal-common": "16.6.2",
+				"jsonwebtoken": "^9.0.0"
 			},
 			"engines": {
-				"node": ">=16"
-			}
-		},
-		"node_modules/@azure/msal-node/node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist/bin/uuid"
+				"node": ">=20"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -4082,9 +4071,9 @@
 			}
 		},
 		"node_modules/glob/node_modules/brace-expansion": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {


### PR DESCRIPTION
## Summary

This PR applies `npm audit fix` to resolve remaining transitive **development-scope** vulnerabilities.

## Changes

- Updated transitive dependencies in `package-lock.json` only
- No source code changes
- No updates to VS Code-related versions (e.g. `engines.vscode`, `@types/vscode`)

## Notable dependency updates (transitive)

- `@azure/identity`: `4.13.0` → `4.13.1`
- `@azure/msal-node`: `3.8.8` → `5.2.2`
- `@azure/msal-common`: `15.15.0` → `16.6.2`
- `@azure/msal-browser`: `4.29.0` → `5.11.0`
- `brace-expansion` (via `glob`): `5.0.5` → `5.0.6`
- Removed vulnerable transitive path `@azure/msal-node/node_modules/uuid@8.3.2`

## Validation

- `npm audit` result: `0 vulnerabilities`
- Unit tests: all passed (`37 passed / 0 failed`)

## Impact

- Security maintenance update for lockfile resolution only
- No intended runtime behavior change in extension source code