### PR TITLE
[codex] bump version to 0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Markdown Live Editor will be documented in this file.
 
+## [0.6.3] - 2026-06-30
+
+### Changed
+
+- Bumped patch version for the next release
+
 ## [0.6.2] - 2026-04-20
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "markdown-live-editor",
-	"version": "0.6.2",
+	"version": "0.6.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "markdown-live-editor",
-			"version": "0.6.2",
+			"version": "0.6.3",
 			"license": "MIT",
 			"dependencies": {
 				"@milkdown/components": "^7.21.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "markdown-live-editor",
 	"displayName": "Markdown Live Editor",
 	"description": "WYSIWYG Markdown editor for VS Code",
-	"version": "0.6.2",
+	"version": "0.6.3",
 	"publisher": "jishii1204",
 	"icon": "icon.png",
 	"license": "MIT",


### PR DESCRIPTION
## Summary
- bump the extension version from `0.6.2` to `0.6.3`
- sync the root version entries in `package-lock.json`
- add a `0.6.3` changelog entry dated 2026-06-30

## Why
- prepare the next patch release with the repository metadata and release notes aligned

## Validation
- `npm run test:all`
- `npm run lint`
- `npm run package`
- `npx vsce package --no-dependencies`