### PR TITLE
[codex] Fix markdown context menu visibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,14 +90,14 @@
 		"menus": {
 			"explorer/context": [
 				{
-					"when": "resourceLangId == markdown",
+					"when": "resourceExtname == .md || resourceLangId == markdown",
 					"command": "markdownLiveEditor.openEditor",
 					"group": "navigation"
 				}
 			],
 			"editor/title/context": [
 				{
-					"when": "resourceLangId == markdown",
+					"when": "resourceExtname == .md || resourceLangId == markdown",
 					"command": "markdownLiveEditor.openEditor",
 					"group": "1_open"
 				}

--- a/test/smoke/manifestSmoke.test.ts
+++ b/test/smoke/manifestSmoke.test.ts
@@ -14,6 +14,7 @@ describe('extension manifest smoke', () => {
 			contributes?: {
 				customEditors?: Array<{ viewType: string }>;
 				commands?: Array<{ command: string }>;
+				menus?: Record<string, Array<{ command: string; when?: string }>>;
 			};
 		};
 
@@ -21,6 +22,20 @@ describe('extension manifest smoke', () => {
 		assert.equal(pkg.browser, './dist/web/extension.js');
 		assert.ok(pkg.contributes?.customEditors?.some((e) => e.viewType === 'markdownLiveEditor.editor'));
 		assert.ok(pkg.contributes?.commands?.some((c) => c.command === 'markdownLiveEditor.openEditor'));
+		assert.ok(
+			pkg.contributes?.menus?.['explorer/context']?.some(
+				(menu) =>
+					menu.command === 'markdownLiveEditor.openEditor' &&
+					menu.when === 'resourceExtname == .md || resourceLangId == markdown',
+			),
+		);
+		assert.ok(
+			pkg.contributes?.menus?.['editor/title/context']?.some(
+				(menu) =>
+					menu.command === 'markdownLiveEditor.openEditor' &&
+					menu.when === 'resourceExtname == .md || resourceLangId == markdown',
+			),
+		);
 	});
 
 	it('has required source entry files', () => {


### PR DESCRIPTION
## Summary
- broaden the markdown context menu  clause to match  files as well as markdown language ids
- add a smoke test covering the explorer and editor title context menu conditions
- keep the fix aligned with the recent manual verification and full test run

## Testing
- npm run check-types
- npm run lint
- node --test .test-dist/test/smoke/manifestSmoke.test.js
- npm run test:all