### PR TITLE
Bump version to 0.6.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "markdown-live-editor",
-	"version": "0.6.3",
+	"version": "0.6.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "markdown-live-editor",
-			"version": "0.6.3",
+			"version": "0.6.4",
 			"license": "MIT",
 			"dependencies": {
 				"@milkdown/components": "^7.21.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "markdown-live-editor",
 	"displayName": "Markdown Live Editor",
 	"description": "WYSIWYG Markdown editor for VS Code",
-	"version": "0.6.3",
+	"version": "0.6.4",
 	"publisher": "jishii1204",
 	"icon": "icon.png",
 	"license": "MIT",


### PR DESCRIPTION
## Summary
- bump extension version from 0.6.3 to 0.6.4
- keep package manifest and lockfile in sync

## Testing
- not run (version-only change)