### PR TITLE
Fix remote updates never applying and moving the caret

### DIFF
--- a/src/view/blockDiffUtils.ts
+++ b/src/view/blockDiffUtils.ts
@@ -1,0 +1,84 @@
+/**
+ * Minimal shape of a ProseMirror node needed to diff top-level blocks.
+ * Declared structurally so this module stays free of ProseMirror imports
+ * and can be unit tested with plain objects.
+ */
+export interface DiffableBlock<T> {
+	readonly nodeSize: number;
+	eq(other: T): boolean;
+}
+
+export interface ChangedBlockRange {
+	/** Start of the replaced range, in current document positions. */
+	from: number;
+	/** End of the replaced range, in current document positions. */
+	to: number;
+	/** Start of the replacement slice, in incoming document positions. */
+	newFrom: number;
+	/** End of the replacement slice, in incoming document positions. */
+	newTo: number;
+}
+
+function totalSize<T extends DiffableBlock<T>>(blocks: readonly T[]): number {
+	let size = 0;
+	for (const block of blocks) {
+		size += block.nodeSize;
+	}
+	return size;
+}
+
+/**
+ * Finds the smallest top-level block range that has to be replaced to turn
+ * `current` into `incoming`, by skipping the blocks that are equal at the
+ * start and at the end.
+ *
+ * Replacing the whole document maps every selection into a range that no
+ * longer exists, so the caret is pushed to the end of the replacement. Keeping
+ * the untouched blocks out of the transaction lets ProseMirror map the
+ * selection normally, which keeps the caret in place whenever the change is
+ * somewhere else in the document.
+ *
+ * When the documents are equal the returned range is empty (`from === to` and
+ * `newFrom === newTo`), which makes the replacement a no-op.
+ */
+export function changedBlockRange<T extends DiffableBlock<T>>(
+	current: readonly T[],
+	incoming: readonly T[],
+): ChangedBlockRange {
+	const currentCount = current.length;
+	const incomingCount = incoming.length;
+
+	let prefix = 0;
+	while (
+		prefix < currentCount &&
+		prefix < incomingCount &&
+		current[prefix].eq(incoming[prefix])
+	) {
+		prefix += 1;
+	}
+
+	let suffix = 0;
+	while (
+		suffix < currentCount - prefix &&
+		suffix < incomingCount - prefix &&
+		current[currentCount - 1 - suffix].eq(incoming[incomingCount - 1 - suffix])
+	) {
+		suffix += 1;
+	}
+
+	let from = 0;
+	let newFrom = 0;
+	for (let i = 0; i < prefix; i += 1) {
+		from += current[i].nodeSize;
+		newFrom += incoming[i].nodeSize;
+	}
+
+	let to = totalSize(current);
+	let newTo = totalSize(incoming);
+	for (let i = 0; i < suffix; i += 1) {
+		to -= current[currentCount - 1 - i].nodeSize;
+		newTo -= incoming[incomingCount - 1 - i].nodeSize;
+	}
+
+	return { from, to, newFrom, newTo };
+}

--- a/src/view/pendingUpdateUtils.ts
+++ b/src/view/pendingUpdateUtils.ts
@@ -1,0 +1,33 @@
+export type PendingUpdateDecision = 'apply' | 'discard' | 'wait';
+
+export interface PendingUpdateInput {
+	/** When the queued snapshot arrived from the extension host. */
+	queuedAt: number;
+	/** When the user last changed the document in the editor. */
+	lastLocalEditAt: number;
+	/** True while local edits have not been posted to the host yet. */
+	hasUnsyncedLocalEdits: boolean;
+}
+
+/**
+ * Decides what to do with a remote update that was queued because the editor
+ * had focus.
+ *
+ * The queued body is a snapshot of the host document taken when the message
+ * arrived, so it only reflects local edits the host already knew about:
+ *
+ * - If the user typed after the snapshot was taken, applying it would revert
+ *   those keystrokes. Discard it instead; the newer local content reaches the
+ *   host through the normal update debounce.
+ * - If local edits have not been posted yet, the snapshot cannot contain them
+ *   even though they are older than it, so wait until they have been sent.
+ * - Otherwise the snapshot is at least as new as anything typed locally and is
+ *   safe to apply.
+ */
+export function decidePendingUpdate(
+	input: PendingUpdateInput,
+): PendingUpdateDecision {
+	if (input.lastLocalEditAt > input.queuedAt) return 'discard';
+	if (input.hasUnsyncedLocalEdits) return 'wait';
+	return 'apply';
+}

--- a/src/view/view.ts
+++ b/src/view/view.ts
@@ -21,6 +21,7 @@ import {
 import { hashText } from '../shared/hash';
 import { alertPlugin } from './alertPlugin';
 import { autoPairPlugin } from './autoPairPlugin';
+import { changedBlockRange } from './blockDiffUtils';
 import { codeBlockPlugin, highlightPlugin } from './codeBlockPlugin';
 import {
 	cleanupTableBr,
@@ -43,6 +44,7 @@ import {
 	mathViewPlugin,
 	remarkMathPlugin,
 } from './katexPlugin';
+import { decidePendingUpdate } from './pendingUpdateUtils';
 import { mountSearchPanel } from './searchPanel';
 import { searchPlugin } from './searchPlugin';
 import { configureSlash, slash, slashKeyboardPlugin } from './slashPlugin';
@@ -93,6 +95,16 @@ let isInitializing = false;
 // Batches rapid keystrokes into a single postMessage call.
 let updateTimer: ReturnType<typeof setTimeout> | null = null;
 const UPDATE_DELAY_MS = 300;
+
+// Remote updates are deferred while the editor is focused so the caret is not
+// disturbed mid-keystroke, but they must still land without waiting for a
+// focusout: undo/redo is handled by VS Code (the webview has no history
+// plugin), so it edits the TextDocument and comes back as a remote update
+// while focus stays in the editor.
+let pendingFlushTimer: ReturnType<typeof setTimeout> | null = null;
+let lastLocalEditAt = 0;
+let pendingQueuedAt = 0;
+const PENDING_POLL_MS = 40;
 let disposeSearchUi: (() => void) | null = null;
 const SYNC_DEBUG_STORAGE_KEY = 'markdownLiveEditor.syncDebug';
 let visualLineNumbersEnabled = false;
@@ -146,6 +158,7 @@ const syncPlugin = $prose((ctx) => {
 					if (isInitializing || isUpdatingFromExtension) return;
 					if (view.state.doc.eq(prevState.doc)) return;
 
+					lastLocalEditAt = Date.now();
 					if (updateTimer) clearTimeout(updateTimer);
 					updateTimer = setTimeout(() => {
 						updateTimer = null;
@@ -353,6 +366,14 @@ async function createEditor(
 	return instance;
 }
 
+function topLevelBlocks(doc: ProseMirrorNode): ProseMirrorNode[] {
+	const blocks: ProseMirrorNode[] = [];
+	doc.content.forEach((child) => {
+		blocks.push(child);
+	});
+	return blocks;
+}
+
 function replaceContent(newMarkdown: string): void {
 	if (!editor) {
 		return;
@@ -377,6 +398,14 @@ function replaceContent(newMarkdown: string): void {
 
 			const parser = ctx.get(parserCtx);
 			const newDoc = parser(newMarkdown);
+			// Replace only the top-level blocks that differ. Replacing the whole
+			// document maps the selection into a range that no longer exists and
+			// pushes the caret to the end of the replacement, which is visible on
+			// every undo and every external edit to the file.
+			const range = changedBlockRange(
+				topLevelBlocks(view.state.doc),
+				topLevelBlocks(newDoc),
+			);
 			syncDebug('replace-apply', {
 				incomingLength: newMarkdown.length,
 				incomingHash: hashText(newMarkdown),
@@ -385,10 +414,28 @@ function replaceContent(newMarkdown: string): void {
 				focus: view.hasFocus(),
 				selectionFrom: view.state.selection.from,
 				selectionTo: view.state.selection.to,
+				replacedFrom: range.from,
+				replacedTo: range.to,
 			});
 			const { tr } = view.state;
-			tr.replaceWith(0, view.state.doc.content.size, newDoc.content);
+			tr.replaceWith(
+				range.from,
+				range.to,
+				newDoc.content.cut(range.newFrom, range.newTo),
+			);
 			view.dispatch(tr);
+
+			// Safety net: a narrowed replacement must reproduce the incoming
+			// document exactly. If it does not, fall back to replacing everything
+			// so content is never left in a wrong state.
+			if (!view.state.doc.eq(newDoc)) {
+				syncDebug('replace-fallback-full', {
+					incomingHash: hashText(newMarkdown),
+				});
+				const fallbackTr = view.state.tr;
+				fallbackTr.replaceWith(0, view.state.doc.content.size, newDoc.content);
+				view.dispatch(fallbackTr);
+			}
 
 			// Update baseline to the new normalized content
 			const updatedDoc = ctx.get(editorStateCtx).doc;
@@ -405,6 +452,13 @@ function replaceContent(newMarkdown: string): void {
 
 function isEditorViewFocused(): boolean {
 	if (!editor) return false;
+	// ProseMirror's hasFocus() compares against root.activeElement, which stays
+	// set after the webview iframe loses focus. Without this check the editor
+	// keeps reporting focus once it has been clicked, so every remote update is
+	// queued and only a later focusout can flush it.
+	if (typeof document.hasFocus === 'function' && !document.hasFocus()) {
+		return false;
+	}
 	let focused = false;
 	try {
 		editor.action((ctx) => {
@@ -430,6 +484,47 @@ function maybeApplyPendingRemoteUpdate(): void {
 	pendingRemoteMarkdown = null;
 	syncDebug('pending-apply', { length: queued.length, hash: hashText(queued) });
 	replaceContent(queued);
+}
+
+// Applies a queued remote update as soon as it is safe to do so, so undo/redo
+// and external file edits land while the editor keeps focus.
+function schedulePendingFlush(): void {
+	if (pendingFlushTimer) clearTimeout(pendingFlushTimer);
+	pendingFlushTimer = setTimeout(() => {
+		pendingFlushTimer = null;
+		if (!pendingRemoteMarkdown) return;
+
+		// updateTimer is non-null exactly while local edits have not reached the
+		// host yet, so it answers "is the snapshot missing local edits?" without
+		// guessing at a quiet period with a fixed delay.
+		const decision = decidePendingUpdate({
+			queuedAt: pendingQueuedAt,
+			lastLocalEditAt,
+			hasUnsyncedLocalEdits: updateTimer !== null,
+		});
+
+		if (decision === 'discard') {
+			syncDebug('pending-discard-stale', {
+				length: pendingRemoteMarkdown.length,
+				hash: hashText(pendingRemoteMarkdown),
+			});
+			pendingRemoteMarkdown = null;
+			return;
+		}
+
+		if (decision === 'wait') {
+			schedulePendingFlush();
+			return;
+		}
+
+		const queued = pendingRemoteMarkdown;
+		pendingRemoteMarkdown = null;
+		syncDebug('pending-apply-idle', {
+			length: queued.length,
+			hash: hashText(queued),
+		});
+		replaceContent(queued);
+	}, PENDING_POLL_MS);
 }
 
 function buildExportHtml(style: string, customStyle: string): string {
@@ -558,10 +653,12 @@ window.addEventListener('message', (event) => {
 			});
 			if (isEditorViewFocused()) {
 				pendingRemoteMarkdown = message.body;
+				pendingQueuedAt = Date.now();
 				syncDebug('host-update-queued', {
 					length: message.body.length,
 					hash: hashText(message.body),
 				});
+				schedulePendingFlush();
 				break;
 			}
 			replaceContent(message.body);

--- a/test/unit/blockDiff.test.ts
+++ b/test/unit/blockDiff.test.ts
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+	changedBlockRange,
+	type DiffableBlock,
+} from '../../src/view/blockDiffUtils';
+
+interface FakeBlock extends DiffableBlock<FakeBlock> {
+	readonly id: string;
+}
+
+function block(id: string, nodeSize = 3): FakeBlock {
+	return {
+		id,
+		nodeSize,
+		eq(other: FakeBlock) {
+			return other.id === id && other.nodeSize === nodeSize;
+		},
+	};
+}
+
+/**
+ * Expands blocks into position space, applies the computed replacement and
+ * checks the result equals the incoming document. This is the property the
+ * range has to satisfy for the ProseMirror transaction to be correct.
+ */
+function assertSpliceMatches(
+	current: readonly FakeBlock[],
+	incoming: readonly FakeBlock[],
+): void {
+	const expand = (blocks: readonly FakeBlock[]) =>
+		blocks.flatMap((b) => Array.from({ length: b.nodeSize }, () => b.id));
+
+	const { from, to, newFrom, newTo } = changedBlockRange(current, incoming);
+	const flatCurrent = expand(current);
+	const flatIncoming = expand(incoming);
+	const spliced = [
+		...flatCurrent.slice(0, from),
+		...flatIncoming.slice(newFrom, newTo),
+		...flatCurrent.slice(to),
+	];
+
+	assert.deepEqual(spliced, flatIncoming);
+}
+
+describe('changedBlockRange', () => {
+	it('returns an empty range for identical documents', () => {
+		const blocks = [block('a'), block('b')];
+		assert.deepEqual(changedBlockRange(blocks, [block('a'), block('b')]), {
+			from: 6,
+			to: 6,
+			newFrom: 6,
+			newTo: 6,
+		});
+	});
+
+	it('narrows the range to a changed block in the middle', () => {
+		const current = [block('a'), block('b'), block('c')];
+		const incoming = [block('a'), block('x'), block('c')];
+		assert.deepEqual(changedBlockRange(current, incoming), {
+			from: 3,
+			to: 6,
+			newFrom: 3,
+			newTo: 6,
+		});
+		assertSpliceMatches(current, incoming);
+	});
+
+	it('handles appended, prepended and removed blocks', () => {
+		const base = [block('a'), block('b')];
+		assertSpliceMatches(base, [block('a'), block('b'), block('c')]);
+		assertSpliceMatches(base, [block('z'), block('a'), block('b')]);
+		assertSpliceMatches([block('a'), block('b'), block('c')], base);
+	});
+
+	it('handles empty documents on either side', () => {
+		assertSpliceMatches([], [block('a')]);
+		assertSpliceMatches([block('a')], []);
+		assertSpliceMatches([], []);
+	});
+
+	it('handles blocks that changed size only', () => {
+		assertSpliceMatches([block('a'), block('b', 3)], [block('a'), block('b', 9)]);
+	});
+
+	it('handles repeated identical blocks', () => {
+		assertSpliceMatches(
+			[block('a'), block('a'), block('a')],
+			[block('a'), block('a')],
+		);
+		assertSpliceMatches([block('a'), block('b'), block('a')], [block('a')]);
+	});
+});

--- a/test/unit/pendingUpdate.test.ts
+++ b/test/unit/pendingUpdate.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { decidePendingUpdate } from '../../src/view/pendingUpdateUtils';
+
+describe('decidePendingUpdate', () => {
+	it('applies a snapshot taken after the last local edit', () => {
+		assert.equal(
+			decidePendingUpdate({
+				queuedAt: 1000,
+				lastLocalEditAt: 600,
+				hasUnsyncedLocalEdits: false,
+			}),
+			'apply',
+		);
+	});
+
+	it('discards a snapshot the user has typed past', () => {
+		assert.equal(
+			decidePendingUpdate({
+				queuedAt: 1000,
+				lastLocalEditAt: 1200,
+				hasUnsyncedLocalEdits: false,
+			}),
+			'discard',
+		);
+	});
+
+	it('discards even when the newer local edits are still unsynced', () => {
+		assert.equal(
+			decidePendingUpdate({
+				queuedAt: 1000,
+				lastLocalEditAt: 1200,
+				hasUnsyncedLocalEdits: true,
+			}),
+			'discard',
+		);
+	});
+
+	it('waits while older local edits have not reached the host', () => {
+		assert.equal(
+			decidePendingUpdate({
+				queuedAt: 1000,
+				lastLocalEditAt: 900,
+				hasUnsyncedLocalEdits: true,
+			}),
+			'wait',
+		);
+	});
+
+	it('applies when nothing has been typed at all', () => {
+		assert.equal(
+			decidePendingUpdate({
+				queuedAt: 1000,
+				lastLocalEditAt: 0,
+				hasUnsyncedLocalEdits: false,
+			}),
+			'apply',
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Three defects in the host → webview update path. They compound, and the
user-visible symptom is that **undo looks broken**: pressing Cmd+Z in the
editor changes nothing for as long as you keep working in it, and when the
change finally appears the caret has jumped.

The webview has no history plugin, so Cmd+Z is not handled by ProseMirror at
all — it falls through to VS Code, which undoes the `TextDocument` edit. That
returns to the webview as an ordinary remote `update`, which is where all three
bugs are.

## Reproduction steps

1. Open any `.md` with the Markdown Live Editor.
2. Type a few words, wait for the 300ms sync, keep the cursor in the editor.
3. Press Cmd+Z.

Observed: nothing changes. The undo lands only after clicking outside the
editor, and the caret then jumps to the end of the document.

Same root cause, second repro: with the editor focused at least once, edit the
same file from a text editor tab or an external tool. The change never reaches
the WYSIWYG view.

## Expected result

Undo applies promptly while the editor keeps focus, external edits show up
without needing a focus change, and the caret stays where it was unless the
change is where the caret is.

## Changes

**1. `isEditorViewFocused()` reported focus forever.** ProseMirror's
`hasFocus()` compares against `root.activeElement`, which keeps pointing at the
editor DOM after the webview iframe loses focus. Once the editor had been
clicked, every remote update was queued into `pendingRemoteMarkdown` and only a
later `focusout` could flush it. Now also requires `document.hasFocus()`.

**2. Queued updates only flushed on `focusout`.** Deferring is still correct
mid-keystroke, so rather than dropping the deferral, a queued update is now
applied as soon as it is safe. "Safe" is decided by `decidePendingUpdate()`,
because the queued body is a *snapshot* of the host document and applying a
stale one silently reverts the user's keystrokes:

| state | decision |
| --- | --- |
| user typed after the snapshot arrived | `discard` — local content wins and reaches the host via the normal debounce |
| local edits not yet posted to the host | `wait` — the snapshot cannot contain them |
| otherwise | `apply` |

`updateTimer` already tracks "local edits have not reached the host yet", so
the wait condition is exact rather than a fixed delay. `lastLocalEditAt` is
stamped in the existing `syncPlugin` update hook, which excludes programmatic
changes. In the case this all exists for — Cmd+Z after a pause — nothing is
unsynced, so the update applies on the next `PENDING_POLL_MS` (40ms) tick.

**3. `replaceContent()` replaced the whole document.** `tr.replaceWith(0,
doc.content.size, …)` maps every selection into a range that no longer exists,
so the caret is pushed to the end of the replacement on *every* remote update.
It now replaces only the top-level block range that actually differs (common
prefix/suffix skip), letting ProseMirror map the selection normally.

## Impact scope

`src/view/view.ts` (remote update path only) plus two new pure helpers in
`src/view/pendingUpdateUtils.ts` and `src/view/blockDiffUtils.ts`. No protocol,
host, or settings changes. The outbound webview → host path, the 300ms
debounce, and the sync guard are untouched.

Secondary benefit: incoming updates no longer rebuild the entire document, so
Mermaid/KaTeX blocks outside the changed range are not re-rendered on each
update.

## Rollback condition

Roll back if `replace-fallback-full` shows up in sync debug logs during normal
editing — that means the narrowed replacement did not reproduce the parsed
document and the safety net had to re-run the old whole-document replace.
Behaviour in that case is identical to today's, so it degrades rather than
breaks. Also roll back if `pending-discard-stale` appears constantly during
ordinary editing — that would mean the host is emitting updates mid-typing for
a reason not accounted for here, and the queued snapshots are never applied.
Each of the three fixes is independent and can be reverted on its own; happy to
split this into three PRs if you prefer.

## Tests

`test/unit/pendingUpdate.test.ts` covers the apply/discard/wait decision,
including the case that matters most: a snapshot the user has typed past must
be discarded whether or not those newer edits have been posted yet.

`test/unit/blockDiff.test.ts` covers the range computation: middle edits,
insertions, deletions, size-only changes, empty documents on either side, and
repeated identical blocks. Each case is checked against a ground-truth splice
in position space, which is the property the ProseMirror transaction depends
on.

In `replaceContent()` the narrowed replacement is additionally verified at
runtime with `view.state.doc.eq(newDoc)`; on mismatch it falls back to the
previous whole-document replace and logs `replace-fallback-full`.

## Not verified locally

I have no Node/npm on this machine, so `npm run check-types`, `npm run lint`
and `npm run test:all` have **not** been run — please expect CI to be the first
real check on the TypeScript. No CHANGELOG entry, since CONTRIBUTING.md handles
that at release time.

What *has* been exercised: the equivalent patches were applied to an installed
0.6.4 build and used for real editing, which is how the stale-snapshot defect in
an earlier version of this change was found — it reverted keystrokes when an
update arrived mid-typing, and `decidePendingUpdate()` is the fix. Both pure
functions were then extracted from that build, type-erased, and run under
JavaScriptCore against the cases described above; all pass.

## Labels

`quality`, `area:sync`
