### PR TITLE
feat(editor): toggle GFM task list checkboxes by clicking them

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ You can export the current editor view as styled HTML in two ways:
 - Click the fold toggle next to a heading to collapse or expand its section
 - Keyboard support: focus the toggle with `Tab`, then press `Enter` or `Space`
 
+### Task Lists
+
+- Click the checkbox of a `- [ ]` item to toggle it between done and not done
+- Only the checkbox itself toggles; clicking the item text places the caret as usual
+
 ### In-editor Find Shortcuts
 
 Because the editor runs inside a webview, it uses its own Find panel.

--- a/src/view/style.css
+++ b/src/view/style.css
@@ -824,6 +824,7 @@ body {
 	border: 1px solid rgba(128, 128, 128, 0.69);
 	border-radius: 3px;
 	background: transparent;
+	cursor: pointer;
 }
 
 .ProseMirror li[data-checked="true"]::before {

--- a/src/view/taskListLogic.ts
+++ b/src/view/taskListLogic.ts
@@ -1,0 +1,43 @@
+/**
+ * Hit testing for the GFM task list checkbox.
+ *
+ * The checkbox has no DOM node of its own: `style.css` draws it as
+ * `li[data-checked]::before`, an absolutely positioned box at the left edge of
+ * the list item (`left: 0; top: 0.25em; width: 1em; height: 1em`). The values
+ * below mirror that rule, so they must be kept in sync with it.
+ */
+
+const CHECKBOX_LEFT_EM = 0;
+const CHECKBOX_TOP_EM = 0.25;
+const CHECKBOX_SIZE_EM = 1;
+
+/** Extra px around the drawn box, so the edges are not hard to hit. */
+const HIT_SLOP_PX = 2;
+
+export interface CheckboxHitTest {
+	/** Click X relative to the list item's border box. */
+	offsetX: number;
+	/** Click Y relative to the list item's border box. */
+	offsetY: number;
+	/** Computed font size of the list item, in px. */
+	fontSize: number;
+}
+
+/**
+ * True when a click landed on the checkbox itself rather than on the item's
+ * text or the margin around it.
+ */
+export function isInsideTaskCheckbox({
+	offsetX,
+	offsetY,
+	fontSize,
+}: CheckboxHitTest): boolean {
+	const left = CHECKBOX_LEFT_EM * fontSize - HIT_SLOP_PX;
+	const right = (CHECKBOX_LEFT_EM + CHECKBOX_SIZE_EM) * fontSize + HIT_SLOP_PX;
+	const top = CHECKBOX_TOP_EM * fontSize - HIT_SLOP_PX;
+	const bottom = (CHECKBOX_TOP_EM + CHECKBOX_SIZE_EM) * fontSize + HIT_SLOP_PX;
+
+	return (
+		offsetX >= left && offsetX <= right && offsetY >= top && offsetY <= bottom
+	);
+}

--- a/src/view/taskListPlugin.ts
+++ b/src/view/taskListPlugin.ts
@@ -1,0 +1,90 @@
+import type { Ctx } from '@milkdown/ctx';
+import type { Node as ProseMirrorNode } from '@milkdown/prose/model';
+import { Plugin, PluginKey } from '@milkdown/prose/state';
+import type { EditorView } from '@milkdown/prose/view';
+import { $prose } from '@milkdown/utils';
+import { isInsideTaskCheckbox } from './taskListLogic';
+
+export const taskListPluginKey = new PluginKey('task-list-plugin');
+
+const TASK_ITEM_SELECTOR = 'li[data-item-type="task"]';
+const FALLBACK_FONT_SIZE_PX = 16;
+
+interface TaskItem {
+	pos: number;
+	node: ProseMirrorNode;
+}
+
+/** The `list_item` ancestor of `li`, or null when it is not a task item. */
+function findTaskItem(view: EditorView, li: HTMLElement): TaskItem | null {
+	let pos: number;
+	try {
+		pos = view.posAtDOM(li, 0);
+	} catch {
+		return null;
+	}
+
+	const resolved = view.state.doc.resolve(pos);
+	for (let depth = resolved.depth; depth >= 1; depth--) {
+		const node = resolved.node(depth);
+		if (node.type.name !== 'list_item') continue;
+		// Plain (non-task) list items carry `checked: null`.
+		if (node.attrs.checked == null) return null;
+		return { pos: resolved.before(depth), node };
+	}
+	return null;
+}
+
+function toggleChecked(view: EditorView, item: TaskItem): void {
+	view.dispatch(
+		view.state.tr.setNodeMarkup(item.pos, undefined, {
+			...item.node.attrs,
+			checked: !item.node.attrs.checked,
+		}),
+	);
+	view.focus();
+}
+
+/**
+ * Makes GFM task list checkboxes clickable.
+ *
+ * The checkbox is a CSS pseudo-element, so it cannot receive events itself.
+ * This resolves the click against the list item and toggles the `checked`
+ * attribute, which serializes back to `- [x]` / `- [ ]`.
+ */
+export const taskListPlugin = $prose((_ctx: Ctx) => {
+	return new Plugin({
+		key: taskListPluginKey,
+		props: {
+			handleDOMEvents: {
+				mousedown(view: EditorView, event: MouseEvent) {
+					if (event.button !== 0) return false;
+
+					const target = event.target;
+					if (!(target instanceof HTMLElement)) return false;
+					const li = target.closest<HTMLElement>(TASK_ITEM_SELECTOR);
+					if (!li) return false;
+
+					const rect = li.getBoundingClientRect();
+					const fontSize =
+						Number.parseFloat(getComputedStyle(li).fontSize) ||
+						FALLBACK_FONT_SIZE_PX;
+					const onCheckbox = isInsideTaskCheckbox({
+						offsetX: event.clientX - rect.left,
+						offsetY: event.clientY - rect.top,
+						fontSize,
+					});
+					if (!onCheckbox) return false;
+
+					const item = findTaskItem(view, li);
+					if (!item) return false;
+
+					// Keep the caret where it was instead of moving it into the item.
+					event.preventDefault();
+					toggleChecked(view, item);
+					return true;
+				},
+			},
+		},
+	});
+});

--- a/src/view/view.ts
+++ b/src/view/view.ts
@@ -47,6 +47,7 @@ import { mountSearchPanel } from './searchPanel';
 import { searchPlugin } from './searchPlugin';
 import { configureSlash, slash, slashKeyboardPlugin } from './slashPlugin';
 import { configureTableBlock, tableBlock } from './tableBlockPlugin';
+import { taskListPlugin } from './taskListPlugin';
 import {
 	configureCustomLinkTooltip,
 	configureSelectionToolbar,
@@ -311,6 +312,7 @@ async function createEditor(
 		.use(visualLineNumbersController.plugin)
 		.use(searchPlugin)
 		.use(headingFoldPlugin)
+		.use(taskListPlugin)
 		.use(codeBlockPlugin)
 		.use(autoPairPlugin)
 		.use(highlightPlugin)

--- a/test/unit/taskListLogic.test.ts
+++ b/test/unit/taskListLogic.test.ts
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { isInsideTaskCheckbox } from '../../src/view/taskListLogic';
+
+// The checkbox is drawn at left: 0, top: 0.25em, 1em square, with 2px of slop.
+// At 16px that is x in [-2, 18] and y in [2, 22].
+const fontSize = 16;
+
+describe('isInsideTaskCheckbox', () => {
+	it('returns true at the center of the checkbox', () => {
+		assert.equal(
+			isInsideTaskCheckbox({ offsetX: 8, offsetY: 12, fontSize }),
+			true,
+		);
+	});
+
+	it('returns true within the slop around each edge', () => {
+		assert.equal(
+			isInsideTaskCheckbox({ offsetX: -2, offsetY: 2, fontSize }),
+			true,
+		);
+		assert.equal(
+			isInsideTaskCheckbox({ offsetX: 18, offsetY: 22, fontSize }),
+			true,
+		);
+	});
+
+	it('returns false for the label text to the right of the checkbox', () => {
+		assert.equal(
+			isInsideTaskCheckbox({ offsetX: 40, offsetY: 12, fontSize }),
+			false,
+		);
+	});
+
+	it('returns false above and below the checkbox', () => {
+		assert.equal(
+			isInsideTaskCheckbox({ offsetX: 8, offsetY: 0, fontSize }),
+			false,
+		);
+		assert.equal(
+			isInsideTaskCheckbox({ offsetX: 8, offsetY: 30, fontSize }),
+			false,
+		);
+	});
+
+	it('returns false for a wrapped second line at the same x', () => {
+		assert.equal(
+			isInsideTaskCheckbox({
+				offsetX: 8,
+				offsetY: 12 + fontSize * 1.5,
+				fontSize,
+			}),
+			false,
+		);
+	});
+
+	it('scales with the item font size', () => {
+		assert.equal(
+			isInsideTaskCheckbox({ offsetX: 30, offsetY: 20, fontSize: 32 }),
+			true,
+		);
+		assert.equal(
+			isInsideTaskCheckbox({ offsetX: 30, offsetY: 20, fontSize: 12 }),
+			false,
+		);
+	});
+});


### PR DESCRIPTION
## Problem

Task list items are rendered, but their checkboxes cannot be clicked. `style.css` draws the box as a `li[data-checked]::before` pseudo-element, which receives no pointer events, and no plugin listens for clicks on the item. The only way to tick a `- [ ]` item in the WYSIWYG editor is to edit the Markdown source.

## Change

A new `taskListPlugin` (`src/view/taskListPlugin.ts`) handles `mousedown` on a task item, resolves the enclosing `list_item` node via `posAtDOM`, and flips its `checked` attribute with `setNodeMarkup`. Because the toggle goes through a transaction rather than the DOM, it serializes back to `- [x]` / `- [ ]` through the normal sync path.

Registered in `view.ts` right after `headingFoldPlugin`.

### Click target

The hit test is bounded to the drawn box on **both** axes, so only the checkbox toggles:

- horizontally `0 .. 1em`, vertically `0.25em .. 1.25em` relative to the item's border box — the same numbers as the CSS rule
- sized from the item's computed font size, so it tracks the editor font rather than assuming 16px
- 2px of slop on each edge so the border is not fiddly to hit

Clicking the label text, the margin to the right of the checkbox, the margin beside a wrapped second line, or the gutter of a nested child item all return `false` and fall through to normal caret placement. `event.preventDefault()` is called only on a real hit, so the caret does not jump when you tick something.

The geometry constants live in `src/view/taskListLogic.ts` (mirroring the existing `autoPairLogic` / `visualLineNumbersUtils` split) and are covered by `test/unit/taskListLogic.test.ts` — center, edge slop, label text, above/below, wrapped line, and font-size scaling.

`cursor: pointer` is added to the checkbox pseudo-element so the target is discoverable.

## Notes

- Non-task list items carry `checked: null` and are ignored, so ordinary bullets and ordered lists are untouched.
- Keyboard support is not included: unlike the heading fold toggle there is no focusable element to `Tab` to, and adding a key handler on the list item would collide with typing. Happy to follow up if you would like an approach for that.
- I could not run `npm run test:all` / `npm run lint` / `npm run package` locally — there is no Node toolchain on this machine. The code follows the existing `headingFoldPlugin` structure and biome config (tabs, single quotes), but please let CI confirm.
