### PR TITLE
Make task checkboxes clickable

### DIFF
--- a/src/view/style.css
+++ b/src/view/style.css
@@ -824,6 +824,7 @@ body {
 	border: 1px solid rgba(128, 128, 128, 0.69);
 	border-radius: 3px;
 	background: transparent;
+	cursor: pointer;
 }
 
 .ProseMirror li[data-checked="true"]::before {

--- a/src/view/taskListLogic.ts
+++ b/src/view/taskListLogic.ts
@@ -1,0 +1,40 @@
+interface MarkdownNode {
+	type: string;
+	checked?: unknown;
+	position?: { start: { offset?: number } };
+	children?: MarkdownNode[];
+}
+
+export function toggleTaskMarker(
+	markdown: string,
+	root: MarkdownNode,
+	taskIndex: number,
+	checked: boolean,
+): string {
+	let currentTask = 0;
+	let taskOffset: number | undefined;
+	const visit = (node: MarkdownNode): void => {
+		if (taskOffset !== undefined) return;
+		const offset = node.position?.start.offset;
+		if (
+			node.type === 'listItem' &&
+			typeof node.checked === 'boolean' &&
+			typeof offset === 'number'
+		) {
+			if (currentTask === taskIndex) {
+				taskOffset = offset;
+				return;
+			}
+			currentTask += 1;
+		}
+		node.children?.forEach(visit);
+	};
+	visit(root);
+	if (taskOffset === undefined) return markdown;
+	const marker = markdown
+		.slice(taskOffset)
+		.match(/^(?:[-+*]|\d+[.)])\s+\[[ xX]\]/)?.[0];
+	if (!marker) return markdown;
+	const checkOffset = taskOffset + marker.lastIndexOf('[') + 1;
+	return `${markdown.slice(0, checkOffset)}${checked ? 'x' : ' '}${markdown.slice(checkOffset + 1)}`;
+}

--- a/src/view/view.ts
+++ b/src/view/view.ts
@@ -4,6 +4,7 @@ import {
 	editorStateCtx,
 	editorViewCtx,
 	parserCtx,
+	remarkCtx,
 	rootCtx,
 	serializerCtx,
 } from '@milkdown/core';
@@ -47,6 +48,7 @@ import { mountSearchPanel } from './searchPanel';
 import { searchPlugin } from './searchPlugin';
 import { configureSlash, slash, slashKeyboardPlugin } from './slashPlugin';
 import { configureTableBlock, tableBlock } from './tableBlockPlugin';
+import { toggleTaskMarker } from './taskListLogic';
 import {
 	configureCustomLinkTooltip,
 	configureSelectionToolbar,
@@ -63,16 +65,25 @@ declare function acquireVsCodeApi(): {
 
 const vscode = acquireVsCodeApi();
 
-function toggleTaskMarker(
-	markdown: string,
-	taskIndex: number,
-	checked: boolean,
-): string {
-	let index = -1;
-	return markdown.replace(/^\s*(?:[-+*]|\d+[.)])\s+\[[ xX]\]/gm, (marker) =>
-		++index === taskIndex
-			? marker.replace(/\[[ xX]\]/, `[${checked ? 'x' : ' '}]`)
-			: marker,
+function isTaskCheckboxClick(
+	listItem: HTMLElement,
+	event: MouseEvent,
+): boolean {
+	const markerStyle = getComputedStyle(listItem, '::before');
+	const markerTop = Number.parseFloat(markerStyle.top);
+	const markerWidth =
+		Number.parseFloat(markerStyle.width) +
+		Number.parseFloat(markerStyle.borderLeftWidth) +
+		Number.parseFloat(markerStyle.borderRightWidth);
+	const markerHeight =
+		Number.parseFloat(markerStyle.height) +
+		Number.parseFloat(markerStyle.borderTopWidth) +
+		Number.parseFloat(markerStyle.borderBottomWidth);
+
+	return (
+		event.offsetX <= markerWidth &&
+		event.offsetY >= markerTop &&
+		event.offsetY <= markerTop + markerHeight
 	);
 }
 
@@ -183,7 +194,7 @@ const syncPlugin = $prose((ctx) => {
 	});
 });
 
-const taskListTogglePlugin = $prose(() => {
+const taskListTogglePlugin = $prose((ctx) => {
 	return new Plugin({
 		props: {
 			handleDOMEvents: {
@@ -192,8 +203,7 @@ const taskListTogglePlugin = $prose(() => {
 					if (
 						!(listItem instanceof HTMLLIElement) ||
 						!listItem.hasAttribute('data-checked') ||
-						event.offsetX >
-							Number.parseFloat(getComputedStyle(listItem, '::before').width)
+						!isTaskCheckboxClick(listItem, event)
 					) {
 						return false;
 					}
@@ -202,13 +212,16 @@ const taskListTogglePlugin = $prose(() => {
 						...view.dom.querySelectorAll('li[data-checked]'),
 					].indexOf(listItem);
 					const checked = listItem.dataset.checked !== 'true';
-					const nextMarkdown = toggleTaskMarker(
-						sourceMarkdown,
-						taskIndex,
-						checked,
-					);
-					if (nextMarkdown === sourceMarkdown) return false;
 					const preserveSource = updateTimer === null;
+					const nextMarkdown = preserveSource
+						? toggleTaskMarker(
+								sourceMarkdown,
+								ctx.get(remarkCtx).parse(sourceMarkdown),
+								taskIndex,
+								checked,
+							)
+						: sourceMarkdown;
+					if (preserveSource && nextMarkdown === sourceMarkdown) return false;
 
 					event.preventDefault();
 					view.dispatch(
@@ -222,6 +235,9 @@ const taskListTogglePlugin = $prose(() => {
 					if (!preserveSource) return true;
 					if (updateTimer) clearTimeout(updateTimer);
 					updateTimer = null;
+					normalizedBaseline = cleanupTableBr(
+						ctx.get(serializerCtx)(view.state.doc),
+					);
 					sourceMarkdown = nextMarkdown;
 					vscode.postMessage({ type: 'update', body: nextMarkdown });
 					return true;
@@ -422,7 +438,6 @@ function replaceContent(newMarkdown: string): void {
 	if (!editor) {
 		return;
 	}
-	sourceMarkdown = newMarkdown;
 	isUpdatingFromExtension = true;
 	try {
 		editor.action((ctx) => {
@@ -433,6 +448,7 @@ function replaceContent(newMarkdown: string): void {
 			);
 
 			if (currentMarkdown === newMarkdown) {
+				sourceMarkdown = newMarkdown;
 				syncDebug('replace-skip-equal', {
 					incomingLength: newMarkdown.length,
 					incomingHash: hashText(newMarkdown),
@@ -455,6 +471,7 @@ function replaceContent(newMarkdown: string): void {
 			const { tr } = view.state;
 			tr.replaceWith(0, view.state.doc.content.size, newDoc.content);
 			view.dispatch(tr);
+			sourceMarkdown = newMarkdown;
 
 			// Update baseline to the new normalized content
 			const updatedDoc = ctx.get(editorStateCtx).doc;

--- a/src/view/view.ts
+++ b/src/view/view.ts
@@ -63,6 +63,19 @@ declare function acquireVsCodeApi(): {
 
 const vscode = acquireVsCodeApi();
 
+function toggleTaskMarker(
+	markdown: string,
+	taskIndex: number,
+	checked: boolean,
+): string {
+	let index = -1;
+	return markdown.replace(/^\s*(?:[-+*]|\d+[.)])\s+\[[ xX]\]/gm, (marker) =>
+		++index === taskIndex
+			? marker.replace(/\[[ xX]\]/, `[${checked ? 'x' : ' '}]`)
+			: marker,
+	);
+}
+
 // Global error handler — show errors visually in the webview
 function showError(msg: string): void {
 	console.error(`[view] ${msg}`);
@@ -87,6 +100,7 @@ let syncDebugSeq = 0;
 // We compare against the normalized baseline to detect real user changes.
 // This prevents the file from being dirtied just by opening it in the editor.
 let normalizedBaseline = '';
+let sourceMarkdown = '';
 let isInitializing = false;
 
 // Debounce timer for sending updates to the extension host.
@@ -161,9 +175,58 @@ const syncPlugin = $prose((ctx) => {
 						});
 						vscode.postMessage({ type: 'update', body: md });
 						normalizedBaseline = md;
+						sourceMarkdown = md;
 					}, UPDATE_DELAY_MS);
 				},
 			};
+		},
+	});
+});
+
+const taskListTogglePlugin = $prose(() => {
+	return new Plugin({
+		props: {
+			handleDOMEvents: {
+				click(view, event) {
+					const listItem = event.target;
+					if (
+						!(listItem instanceof HTMLLIElement) ||
+						!listItem.hasAttribute('data-checked') ||
+						event.offsetX >
+							Number.parseFloat(getComputedStyle(listItem, '::before').width)
+					) {
+						return false;
+					}
+
+					const taskIndex = [
+						...view.dom.querySelectorAll('li[data-checked]'),
+					].indexOf(listItem);
+					const checked = listItem.dataset.checked !== 'true';
+					const nextMarkdown = toggleTaskMarker(
+						sourceMarkdown,
+						taskIndex,
+						checked,
+					);
+					if (nextMarkdown === sourceMarkdown) return false;
+					const preserveSource = updateTimer === null;
+
+					event.preventDefault();
+					view.dispatch(
+						view.state.tr.setNodeAttribute(
+							view.posAtDOM(listItem, 0) - 1,
+							'checked',
+							checked,
+						),
+					);
+					view.focus();
+					if (!preserveSource) return true;
+					if (updateTimer) clearTimeout(updateTimer);
+					updateTimer = null;
+					sourceMarkdown = nextMarkdown;
+					vscode.postMessage({ type: 'update', body: nextMarkdown });
+					return true;
+				},
+			},
 		},
 	});
 });
@@ -289,6 +352,7 @@ async function createEditor(
 	markdown: string,
 ): Promise<Editor> {
 	isInitializing = true;
+	sourceMarkdown = markdown;
 
 	const instance = Editor.make()
 		.config((ctx) => {
@@ -297,6 +361,7 @@ async function createEditor(
 		})
 		.use(commonmark)
 		.use(gfm)
+		.use(taskListTogglePlugin)
 		.use(tableBlock)
 		.config(configureTableBlock)
 		.use(remarkFrontmatterPlugin)
@@ -357,6 +422,7 @@ function replaceContent(newMarkdown: string): void {
 	if (!editor) {
 		return;
 	}
+	sourceMarkdown = newMarkdown;
 	isUpdatingFromExtension = true;
 	try {
 		editor.action((ctx) => {

--- a/test/unit/taskListLogic.test.ts
+++ b/test/unit/taskListLogic.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { toggleTaskMarker } from '../../src/view/taskListLogic';
+
+function taskAt(markdown: string, marker: string, checked: boolean) {
+	return {
+		type: 'listItem',
+		checked,
+		position: { start: { offset: markdown.indexOf(marker) } },
+	};
+}
+
+describe('toggleTaskMarker', () => {
+	it('changes only the selected parsed task marker in either direction', () => {
+		const markdown = '# Tasks\n\n- [ ] First\n  * [x] Nested\n1. [ ] Ordered\n';
+		const expected = '# Tasks\n\n- [ ] First\n  * [x] Nested\n1. [x] Ordered\n';
+		assert.equal(
+			toggleTaskMarker(
+				markdown,
+				{
+					type: 'root',
+					children: [
+						{ type: 'code', position: { start: { offset: 0 } } },
+						{
+							...taskAt(markdown, '- [ ] First', false),
+							children: [taskAt(markdown, '* [x] Nested', true)],
+						},
+						taskAt(markdown, '1. [ ] Ordered', false),
+					],
+				},
+				2,
+				true,
+			),
+			expected,
+		);
+		assert.equal(
+			toggleTaskMarker(
+				'- [x] Done\n',
+				taskAt('- [x] Done\n', '- [x] Done', true),
+				0,
+				false,
+			),
+			'- [ ] Done\n',
+		);
+	});
+});


### PR DESCRIPTION
## Summary
- Make task checkboxes clickable in the editor.
- Preserve the surrounding Markdown when toggling a checkbox.

## Changes
- Handle clicks on task checkbox markers.
- Update only the selected `[ ]` or `[x]` marker.
- Add focused tests for task selection and source preservation.

## Reproduction steps
1. Open a Markdown file containing `- [ ] Task` with Markdown Live Editor.
2. Click the checkbox marker.
3. Before this change, the checkbox does not toggle.

## Expected result
The selected checkbox toggles without changing unrelated Markdown.